### PR TITLE
Rename obfuscated helpers in bundle.js

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,1 +1,1648 @@
-function a0_0x2f59(){const _0x56bc72=['Error\x20during\x20order\x20processing','Error:','bsTarget','replace','.extras-quantity-control','Token\x20yenileme\x20hatası:','CHF\x20','true','Complété.','En\x20route.','produit',')\x27\x20class=\x27btn\x20btn-sm\x20btn-light\x20border\x20border-secondary\x27>+\x20Ajoutez\x20le\x20même\x20panier.</button>\x0a','toLowerCase','produits','isArray','emporter','Request\x20failed\x20with\x20status\x20','\x0a\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20<div\x20class=\x22d-flex\x20justify-content-center\x20align-items-center\x22\x20style=\x22height:\x20100px;\x22>\x0a\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20<i\x20class=\x22fa\x20fa-check-circle\x22\x20style=\x22color:\x20green;\x20font-size:\x2050px;\x22></i>\x0a\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20</div>\x0a\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20Les\x20produits\x20sont\x20à\x20nouveau\x20ajoutés\x20à\x20votre\x20panier.\x20<br\x20/>\x0a\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20La\x20page\x20sera\x20actualisée\x20dans\x20<span\x20id=\x22countdown\x22>3</span>\x20secondes.\x0a\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20','fa-minus','from','Quantity\x20input\x20not\x20found\x20for\x20index:\x20','#free_sauce_select_','free_sauces','quantity','.dessert-quantity-control','\x0a\x20\x20\x20\x20\x20\x20</select>\x0a\x20\x20\x20\x20','#tacosEditForm\x20input[name=\x22garniture[]\x22][value=\x22','GigaTacos-Lausanne/1.0','scrollY','Accès\x20refusé.\x20Veuillez\x20réessayer.','querySelector','Failed\x20to\x20fetch\x20tacos\x20details:','input[name=\x22viande[]\x22][value=\x22','#tacosEditForm\x20input[name=\x22sauce[]\x22]:checked','ET\x20Network\x20response\x20was\x20not\x20ok','div','keys','extra_mozarella_sticks','#products-list','edit_','ArrowUp','ArrowDown','click','Place\x20','change','top','Tacos','kebab_agneau','innerHTML','reload','/office/stock_management.php?type=all','tacos','index','orderHistory','<div\x20class=\x22col-12\x22><div\x20class=\x22ratio\x20ratio-21x9\x22><iframe\x20src=\x22https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d753.1811493066484!2d6.234256817728024!3d46.38414476416726!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x478c4379e1a8a053%3A0x7f520735d631d6d0!2sGIGA%20TACOS!5e1!3m2!1sfr!2sch!4v1740508995475!5m2!1sfr!2sch\x22\x20allowfullscreen=\x22\x22\x20loading=\x22lazy\x22\x20referrerpolicy=\x22no-referrer-when-downgrade\x22></iframe></div></div>','setItem','<p\x20class=\x27card-title\x20text-end\x20text-warning\x27>Pré-commande\x20pour:\x20','Appuyez\x20sur\x20l’icône\x20de\x20partage\x20(en\x20bas\x20au\x20centre)\x20et\x20sélectionnez\x20«\x20Ajouter\x20à\x20l’écran\x20d’accueil\x20».','repeatOrder','content=livraison','.</span>\x0a\x20\x20\x20\x20\x20\x20<select\x20class=\x22form-control\x20text-danger\x20form-select-sm\x22\x20name=\x22free_sauce_','confirmPhone','.meat-quantity-input','touchstart','success','viande','escalope_de_poulet','focus','span','À\x20emporter','json','application/json','<i\x20class=\x22fas\x20fa-times\x20me-2\x22></i>Erreur\x20-\x20Veuillez\x20réessayer','querySelectorAll','24MyeVhb','extra_pommes_gaufrettes','CS\x20REFRESH','RESTORE\x20ORDER\x20REFRESH','date','GTD\x20REFRESH','append','out_of_stock_items','toggle','i.fas','Unexpected\x20response\x20structure:','Error\x20type:','Creating','<li\x20class=\x27list-group-item\x27>\x0a\x20\x20<span\x20class=\x22border\x20rounded\x20py-1\x20px-2\x22>','set','Viande\x20data:','Fetch\x20Error:','status','.accordion-button\x20i.fas','div:contains(\x22Tacos\x20dans\x20votre\x20panier\x22)','frites_note','event','Unknown\x20category:','trim','<p\x20class=\x22fst-italic\x22>Veuillez\x20commencer\x20par\x20choisir\x20la\x20taille\x20de\x20vos\x20tacos.</p>','label','_div','.boisson-quantity-control','tacos_BOWL','#tacosEditForm\x20.increase-meat','getItem','Hata:','\x20(Temporairement\x20épuisé)','get','error','ajax/oh.php','extras','onload','tacos_L','Problème\x20de\x20connexion.\x20Vérifiez\x20votre\x20connexion\x20internet\x20et\x20réessayez.','sauce','shrink','then','data-order-id','type','.meat-quantity-control','input[name=\x22viande[]\x22][value=\x22sans\x22]:checked','opacity','\x0a</div>\x0a<div\x20class=\x27card-body\x27>\x0a','price','html','updateFreeSauceOptions\x20called\x20with:','dataset','Une\x20erreur\x20est\x20survenue\x20lors\x20de\x20la\x20soumission\x20du\x20formulaire.\x20Veuillez\x20réessayer.','text','style','.out-of-stock-text','accordionState','pedestrian','open','.meat-selection-row','push','extra_gaufrettes','data-boisson-id','desserts','input[name=\x22garniture[]\x22]:checked','.dessert-quantity-control\x20.increase,\x20.dessert-quantity-control\x20.decrease','in_stock','ajax/gsd.php','DOMContentLoaded','Boissons','add_','target','Dans\x20le\x20menu\x20du\x20navigateur\x20(en\x20haut\x20à\x20droite),\x20sélectionnez\x20«\x20Ajouter\x20à\x20l’écran\x20d’accueil\x20».','2523257UGqzeR','GSE\x20REFRESH','#tacosEditForm\x20.decrease-meat','address','log','#product-messages','</em>','\x0a\x20\x20\x20\x20\x20\x20\x20\x20<div\x20class=\x22street\x22>','children','openOrderModal','sauces','reset','button[onclick=\x27repeatOrder(','.autocomplete-item','shown.bs.collapse','sauce\x20options\x20for','orderModal','data-dessert-id','ajax/os.php','preventDefault','_isExactMatch','.decrease-quantity','editTaille','message','ajax/owt.php','orderAccordion','0.5','127.0.0.1','free_sauce_','attr','#tacosEditForm\x20input[name=\x22viande[]\x22]:checked','filter','<i\x20class=\x22fas\x20fa-wifi\x20me-2\x22></i>Erreur\x20de\x20connexion','input[name=\x22boisson\x22]','value','</p>','availableSauces','GET','FORBIDDEN','ajax/ues.php','Website','input[name=\x22sauce[]\x22]','orderForm','.accordion-button','requestedFor','Error\x20during\x20processing.','</p>\x0a','totalQuantity','tacos_GIGA','time_slots','96597GvhQYz','hidden.bs.modal','free-sauce-item\x20d-flex\x20flex-column\x20flex-sm-row\x20align-items-start\x20align-items-sm-center\x20mb-2\x20mt-1','className','submit','forEach','smooth','tacos_XXL','ondelivery','autocompleteDropdown','offsetHeight','RESTORE\x20ORDER\x20Network\x20response\x20was\x20not\x20ok','block','falafel_vegetarien','\x20.accordion-button\x20.badge','card\x20mb-3\x20text-','-subtle\x20text-success\x20rounded\x20opacity-75\x22>','sort','csrf_token','.add-tacos-button','free_sauce','.quantity-input','Veuillez\x20sélectionner\x20au\x20moins\x20une\x20sauce\x20ou\x20cocher\x20\x22sans\x20sauce\x22.','gruyere','OH\x20Network\x20response\x20was\x20not\x20ok','addEventListener','getMinutes','parse','show.bs.modal','order_stories','btn-success','select[name=\x22requestedFor\x22]','editTacosNote','OrderData','input','ajax/gse.php','frites','OS\x20REFRESH','.boissons-info','length','scrollTo','Êtes-vous\x20sûr\x20de\x20vouloir\x20supprimer\x20ce\x20produit\u00a0?','modal','tacosEditModal','<button\x20class=\x27btn\x20btn-sm\x20btn-light\x20border\x20border-secondary\x27\x20disabled>+\x20Ajoutez\x20le\x20même\x20panier.</button>','option[value]:not([value=\x22\x22])','selectSnacks','https://nominatim.openstreetmap.org/search?','addToHomeText','matches','GSD\x20Network\x20response\x20was\x20not\x20ok','</span>\x20x\x20','<div\x20class=\x22p-2\x20mb-2\x20bg-','RATE_LIMIT','key','is_high_demand','search','./images/android-share.png','599615ewAQXW','demandMessage','transaction_id','show','ajax/RocknRoll.php','now','ajax/gtd.php','<ul\x20class=\x27list-group\x20list-group-flush\x27>','same-origin','#tacos-','data-tacos-type','&meat_quantity[','.header','ajax/dt.php','.free-sauce-checkbox','send','display','.decrease-meat','appendChild','test','stringify','meat_quantity[','house_number','\x0a<button\x20onclick=\x27repeatOrder(','Route\x20','livraison','autocomplete-item','<br><strong>-\x20Viande(s):</strong>\x20<em>','add','GTD\x20Network\x20response\x20was\x20not\x20ok','.form-check','Switzerland','10olAkQs','ajax/gsb.php','</ul></div>','input[name=\x22garniture[]\x22][value=\x22sans\x22]:checked','createElement','Order\x20not\x20found.','input[name=\x22extras\x22]','input[name=\x22garniture[]\x22]','content','Delivery\x20demand\x20check\x20error:','Modal','toDateString','removeEventListener','\x20</em>','entries','totalPrice','Votre\x20commande\x20a\x20été\x20confirmée\x20et\x20sera\x20préparée\x20pour\x20la\x20livraison.\x20Celui-ci\x20sera\x20mis\x20à\x20jour\x20lorsque\x20votre\x20commande\x20sera\x20en\x20route.','8365331DNtAMg','road','ajax/et.php','contains','[]\x22\x20data-item-index=\x22','free_sauce_select_','<i\x20class=\x22fas\x20fa-check\x20me-2\x22></i>Commande\x20confirmée!','btn-warning','CS\x20Network\x20response\x20was\x20not\x20ok','selectedIndex','hostname','<option\x20value=\x22\x22\x20disabled>Choisissez\x20votre\x20sauce\x20offerte\x20ici.</option>','location','.modal','\x0a<p\x20class=\x27card-subtitle\x20mb-2\x20mt-1\x20text-muted\x20text-end\x27>Montant\x20total\x20à\x20payer\x20:\x20','d-none','REFRESH\x20TOKEN\x20ERROR','<option\x20value=\x22','#tacosEditModal','input[name^=\x22garniture\x22]','successModal','editSelectProduct','Escape','\x20(Forte\x20affluence)','extra_nuggets','statusText','#tacosEditForm\x20input[type=\x22checkbox\x22]','values','ajax/sd.php','#tacosEditForm\x20.meat-quantity-control','responseText','viandes','Content-Type','\x20select','localhost','selectProduct','stack','.increase-meat','DUPLICATE_ORDER','<i\x20class=\x22fas\x20fa-info-circle\x20me-2\x22></i>Cette\x20commande\x20a\x20déjà\x20été\x20traitée','#successModal','catch',')\x27]','classList','join','>Choisissez\x20votre\x20sauce\x20offerte\x20ici.</option>','2274928lELkyP','dispatchEvent','slug','</div>\x0a\x20\x20\x20\x20\x20\x20','out-of-stock-text\x20text-danger\x20ms-2','\x20text-body-secondary\x20rounded\x20opacity-75\x22>La\x20commande\x20a\x20été\x20annulée.</div>','Votre\x20commande\x20a\x20été\x20confirmée\x20et\x20sera\x20prête\x20pour\x20le\x20retrait.','btn-danger','#tacosEditForm\x20input[name=\x22garniture[]\x22]:checked','Connection\x20error.\x20Please\x20refresh\x20the\x20page.','delivered','<div\x20class=\x22d-flex\x20justify-content-center\x20align-items-center\x22\x20style=\x22height:\x20100px;\x22><i\x20class=\x27fa\x20fa-check-circle\x27\x20style=\x27color:\x20green;\x20font-size:\x20100px;\x20margin-right:\x2015px;\x27></i>Votre\x20commande\x20a\x20été\x20reçue\x20et\x20sera\x20préparée.</div>','#orderModal\x20.order-summary','Saved\x20selections:','parentElement','select','textContent','sans_viande','application/x-www-form-urlencoded','null','\x0a\x20\x20\x20\x20\x20\x20<i\x20class=\x22fa-solid\x20fa-angles-up\x22\x20style=\x22font-size:\x2022px;\x20margin-right:\x208px;\x20color:#dc3545\x22></i>\x0a\x20\x20\x20\x20\x20\x20<span\x20class=\x22text-danger\x20me-2\x22>','Error\x20during\x20repeat\x20order.\x20Please\x20try\x20again\x20later.','increase','Les\x20numéros\x20de\x20téléphone\x20ne\x20correspondent\x20pas,\x20veuillez\x20vérifier\x20!','#products-list\x20.card',':00','danger','input[name=\x22extra[]\x22]','input[name=\x22sauce[]\x22]:checked','cordon_bleu','#confirmMinOrderModal\x20.btn-danger','<div\x20class=\x22alert\x20alert-success\x20mx-auto\x20mt-4\x22\x20style=\x22max-width:\x20500px;\x20background-color:\x20#d4edda;\x20border-left:\x204px\x20solid\x20#28a745;\x22><i\x20class=\x22fa\x20fa-check-circle\x20text-success\x20me-2\x22></i>Les\x20autres\x20produits\x20ont\x20été\x20ajoutés\x20avec\x20succès.</div><button\x20id=\x22continueButton\x22\x20class=\x22btn\x20btn-danger\x20mt-3\x22\x20style=\x22min-width:\x20200px;\x20padding:\x2012px\x2024px;\x20font-size:\x2016px;\x20border-radius:\x2025px;\x20box-shadow:\x200\x204px\x2015px\x20rgba(220,\x2053,\x2069,\x200.3);\x22>Continuer\x20vers\x20le\x20panier</button></div>','POST','csrf_token=','input[name=\x22viande[]\x22]:checked','Avenue\x20','viande_hachee','extra_onion_rings','CHF','Error\x20checking\x20all\x20time\x20slots:','hide','deliveryDemandWarning','getTime','ajax','selected','GSE\x20Network\x20response\x20was\x20not\x20ok','Chemin\x20','.extra-checkbox','action=','each','12xQhMwq','tacosAddModal','continueButton','12IwpOdC','disabled','7rcSzwj','5rHxEkT','tenders','ajax/uds.php','active','extra_potatoes','</strong></li>','cancelled','.free-sauces-container','Veuillez\x20sélectionner\x20au\x20moins\x20une\x20viande\x20ou\x20cocher\x20\x22sans\x20viande\x22.','undefined','getBoundingClientRect','checked','<br>-\x20<strong>Sauce\x20offerte:</strong>\x20<em>','tacos_L_mixte','extra_falafel','options','includes','name','.extras-info','input[name=\x22boissons\x22]','mouseenter','Network','body','Vous\x20avez\x20déjà\x20passé\x20une\x20commande\x20récemment.\x20Veuillez\x20patienter\x201\x20minute\x20avant\x20de\x20commander\x20à\x20nouveau.','bannerLogo','<span\x20class=\x22spinner-border\x20spinner-border-sm\x20me-2\x22></span>Traitement\x20en\x20cours...','input[name=\x22csrf_token\x22]','extra_tenders','removeItem','.modal-backdrop','phone','ajax/refresh_token.php','remove','getAttribute','pending','ajax/check_delivery_demand.php','none','max','setRequestHeader','Network\x20response\x20was\x20not\x20ok','map','.collapse.show','Maximum','index=','.increase-quantity','css','data-index','extra_frites','Created','.whatsapp-icon','tacos_XL','object','keydown','tacosNote','confirmed','#tacosEditForm\x20input[name=\x22viande[]\x22]','.delete-tacos','closest','\x20total\x20','data','nuggets','ready','35718bGQLkS','input[name^=\x22sauce\x22]','</p>\x0a<p\x20class=\x27card-title\x20text-end\x27>Préférence:\x20','89222GNXQsS','\x0a\x20\x20</li>','Collapse','postcode','scroll','pointerEvents','Delivery\x20demand\x20initialization\x20error:','\x20text-white\x20rounded\x20opacity-75\x22>Votre\x20commande\x20a\x20été\x20préparée\x20et\x20le\x20livreur\x20est\x20en\x20route.\x20<b>Restez\x20joignable\x20s\x27il\x20vous\x20plaît.</b>\x20Livraison\x20assurée\x20à\x20l\x27entrée\x20de\x20l\x27immeuble\x20merci\x20pour\x20votre\x20compréhension.</div>','Error\x20loading\x20the\x20order\x20summary:','fa-plus','concat','input[name=\x22desserts\x22]','auto','garniture','.extras-quantity-control\x20.increase,\x20.extras-quantity-control\x20.decrease','boissons','orderId','Forte\x20affluence','#orderModal','input[name=\x22viande[]\x22]','toString','(Temporairement\x20épuisé)','.desserts-info','warning','getElementById','collapsed','secondary','Livraison','cart-summary','Votre\x20commande\x20a\x20été\x20reçue.','#tacosAddModal','createTacos','getHours','input[name=\x22viande\x22],\x20input[name=\x22viande[]\x22]','Stock\x20status\x20fetch\x20failed','find','shown.bs.modal','soudjouk','\x0a<div\x20class=\x27card-header\x20d-flex\x20justify-content-between\x20align-items-center\x27>\x0a','No\x20container\x20found\x20for:','<br>-\x20<strong>Sauces\x20offertes:</strong>\x20<em>'];a0_0x2f59=function(){return _0x56bc72;};return a0_0x2f59();}function a0_0x43d4(_0x228635,_0x2bf031){const _0x2f59de=a0_0x2f59();return a0_0x43d4=function(_0x43d409,_0x17b2d8){_0x43d409=_0x43d409-0x14c;let _0x234ba5=_0x2f59de[_0x43d409];return _0x234ba5;},a0_0x43d4(_0x228635,_0x2bf031);}(function(_0x4bb227,_0x311118){const _0x46dd35=a0_0x43d4,_0x2fa55d=_0x4bb227();while(!![]){try{const _0x2fa317=parseInt(_0x46dd35(0x1e0))/0x1*(parseInt(_0x46dd35(0x221))/0x2)+parseInt(_0x46dd35(0x21e))/0x3*(parseInt(_0x46dd35(0x294))/0x4)+-parseInt(_0x46dd35(0x34a))/0x5*(parseInt(_0x46dd35(0x1da))/0x6)+-parseInt(_0x46dd35(0x1df))/0x7*(parseInt(_0x46dd35(0x1a8))/0x8)+-parseInt(_0x46dd35(0x310))/0x9+parseInt(_0x46dd35(0x169))/0xa*(-parseInt(_0x46dd35(0x2de))/0xb)+-parseInt(_0x46dd35(0x1dd))/0xc*(-parseInt(_0x46dd35(0x17a))/0xd);if(_0x2fa317===_0x311118)break;else _0x2fa55d['push'](_0x2fa55d['shift']());}catch(_0x3b3e33){_0x2fa55d['push'](_0x2fa55d['shift']());}}}(a0_0x2f59,0x2a64e),((()=>{const _0x537fe3=a0_0x43d4;function _0x47aee6(){const _0x18464e=a0_0x43d4;return document[_0x18464e(0x268)](_0x18464e(0x1fa))[_0x18464e(0x300)];}var _0x5dfec8;window['addEventListener'](_0x537fe3(0x225),function(){const _0x36bed1=_0x537fe3;var _0x1c226f=document['querySelector'](_0x36bed1(0x211));window[_0x36bed1(0x266)]>0x32&&(document[_0x36bed1(0x268)](_0x36bed1(0x155))[_0x36bed1(0x1a5)][_0x36bed1(0x165)](_0x36bed1(0x2bd)),_0x1c226f['style'][_0x36bed1(0x159)]='block');}),$(document)[_0x537fe3(0x21d)](function(){const _0x1535d2=_0x537fe3;$(_0x1535d2(0x187))['on'](_0x1535d2(0x311),function(){const _0x58d579=_0x1535d2;$(_0x58d579(0x1fd))[_0x58d579(0x200)](),$(_0x58d579(0x1f6))[_0x58d579(0x20d)]({'overflow':'','padding-right':''});});}),document[_0x537fe3(0x293)]('.accordion-button')[_0x537fe3(0x315)](_0x743a72=>{const _0x40b1ef=_0x537fe3;_0x743a72[_0x40b1ef(0x329)](_0x40b1ef(0x274),function(){const _0x4ade2d=_0x40b1ef,_0x55d89e=_0x743a72[_0x4ade2d(0x1a5)]['contains'](_0x4ade2d(0x23a)),_0x4d7d8b=_0x743a72[_0x4ade2d(0x268)](_0x4ade2d(0x29d));(document[_0x4ade2d(0x293)](_0x4ade2d(0x2a6))[_0x4ade2d(0x315)](_0x60fe56=>{const _0x1de63d=_0x4ade2d;_0x60fe56[_0x1de63d(0x1a5)]['remove'](_0x1de63d(0x25c)),_0x60fe56[_0x1de63d(0x1a5)][_0x1de63d(0x165)](_0x1de63d(0x22a));}),_0x55d89e?(_0x4d7d8b[_0x4ade2d(0x1a5)][_0x4ade2d(0x200)](_0x4ade2d(0x25c)),_0x4d7d8b[_0x4ade2d(0x1a5)][_0x4ade2d(0x165)](_0x4ade2d(0x22a))):(_0x4d7d8b[_0x4ade2d(0x1a5)]['remove']('fa-plus'),_0x4d7d8b[_0x4ade2d(0x1a5)][_0x4ade2d(0x165)](_0x4ade2d(0x25c))),!_0x55d89e)&&document[_0x4ade2d(0x268)](_0x743a72[_0x4ade2d(0x2c8)][_0x4ade2d(0x24c)])[_0x4ade2d(0x329)](_0x4ade2d(0x2ec),function(){const _0x26fa5b=_0x4ade2d,_0x50cf97=document[_0x26fa5b(0x268)](_0x26fa5b(0x155))[_0x26fa5b(0x31a)],_0x18e104=_0x743a72[_0x26fa5b(0x1ea)]()[_0x26fa5b(0x277)]+window[_0x26fa5b(0x266)]-_0x50cf97-0x14;window[_0x26fa5b(0x338)]({'top':_0x18e104,'behavior':_0x26fa5b(0x316)});},{'once':!0x0});});}),setInterval(function(){const _0x204e8d=_0x537fe3;fetch(_0x204e8d(0x1ff),{'method':_0x204e8d(0x303),'credentials':_0x204e8d(0x151)})['then'](_0x312011=>{const _0x269fe9=_0x204e8d;if(!_0x312011['ok'])throw 0x193===_0x312011[_0x269fe9(0x2a5)]&&console[_0x269fe9(0x2e2)](_0x269fe9(0x18a)),new Error('REFRESH\x20TOKEN\x20Network\x20response\x20was\x20not\x20ok');return _0x312011['json']();})[_0x204e8d(0x2be)](_0x16c997=>{const _0x345875=_0x204e8d;_0x16c997[_0x345875(0x322)]&&(document[_0x345875(0x268)](_0x345875(0x1fa))[_0x345875(0x300)]=_0x16c997[_0x345875(0x322)]);})['catch'](_0x56c03d=>console[_0x204e8d(0x2b6)](_0x204e8d(0x24f),_0x56c03d));},0x1b7740),document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){_0x21da7d();});function _0x21da7d(){const _0x19e656=_0x537fe3;var _0x8db546=document[_0x19e656(0x239)](_0x19e656(0x27f)),_0x2f3d6c=JSON[_0x19e656(0x32b)](localStorage['getItem'](_0x19e656(0x32d))||'[]'),_0x7e2a0f=_0x47aee6();fetch(_0x19e656(0x2b7),{'method':_0x19e656(0x1c8),'headers':{'Content-Type':_0x19e656(0x291),'X-CSRF-Token':_0x7e2a0f},'body':JSON[_0x19e656(0x15d)]({'orders':_0x2f3d6c[_0x19e656(0x208)](_0x17e0c6=>({'orderId':_0x17e0c6[_0x19e656(0x231)]}))})})['then'](_0x302237=>{const _0x4fa9ad=_0x19e656;if(!_0x302237['ok'])throw 0x193===_0x302237[_0x4fa9ad(0x2a5)]&&window['location'][_0x4fa9ad(0x27b)](),new Error(_0x4fa9ad(0x328));return _0x302237[_0x4fa9ad(0x290)]();})[_0x19e656(0x2be)](_0x285fc8=>{const _0x1e7e10=_0x19e656;Array['isArray'](_0x285fc8)||(_0x285fc8=[]);let _0x533c8e=!0x1;_0x285fc8[_0x1e7e10(0x315)](_0x17fd88=>{const _0x1c9191=_0x1e7e10,_0x540227=_0x2f3d6c['findIndex'](_0x31f23e=>_0x31f23e[_0x1c9191(0x231)]===_0x17fd88[_0x1c9191(0x231)]);-0x1!==_0x540227&&_0x2f3d6c[_0x540227][_0x1c9191(0x331)][_0x1c9191(0x2a5)]!==_0x17fd88[_0x1c9191(0x2a5)]&&(_0x2f3d6c[_0x540227][_0x1c9191(0x331)][_0x1c9191(0x2a5)]=_0x17fd88[_0x1c9191(0x2a5)],_0x533c8e=!0x0);}),_0x8db546[_0x1e7e10(0x27a)]='',_0x2f3d6c['sort']((_0x4e06b8,_0x135b23)=>new Date(_0x135b23['OrderData']['date'])-new Date(_0x4e06b8[_0x1e7e10(0x331)][_0x1e7e10(0x298)])),_0x2f3d6c=_0x2f3d6c['slice'](0x0,0x3);let _0x1bfb86=!0x1;_0x2f3d6c[_0x1e7e10(0x315)](_0xc6ac1d=>{const _0x19773c=_0x1e7e10;new Date(_0xc6ac1d[_0x19773c(0x331)][_0x19773c(0x298)])['toDateString']()===new Date()[_0x19773c(0x174)]()||'pending'!==_0xc6ac1d[_0x19773c(0x331)][_0x19773c(0x2a5)]&&_0x19773c(0x216)!==_0xc6ac1d[_0x19773c(0x331)][_0x19773c(0x2a5)]&&_0x19773c(0x318)!==_0xc6ac1d[_0x19773c(0x331)]['status']?_0x19773c(0x202)!==_0xc6ac1d[_0x19773c(0x331)][_0x19773c(0x2a5)]&&'confirmed'!==_0xc6ac1d[_0x19773c(0x331)][_0x19773c(0x2a5)]&&'ondelivery'!==_0xc6ac1d[_0x19773c(0x331)][_0x19773c(0x2a5)]||(_0x1bfb86=!0x0):_0xc6ac1d['OrderData'][_0x19773c(0x2a5)]='delivered';const _0x238232=function(_0x3c1552){const _0x326cac=_0x19773c,_0x36ab7d=function(_0x7355e){const _0x229f65=a0_0x43d4;let _0x709a68=_0x229f65(0x150);return _0x709a68+=_0x1583ba(_0x7355e[_0x229f65(0x27d)],_0x229f65(0x278)),_0x709a68+=_0x1583ba(_0x7355e[_0x229f65(0x2b8)],'Extras'),_0x709a68+=_0x1583ba(_0x7355e[_0x229f65(0x230)],_0x229f65(0x2da)),_0x709a68+=_0x1583ba(_0x7355e[_0x229f65(0x2d4)],'Desserts'),_0x709a68+='</ul>',_0x709a68;}(_0x3c1552),_0x4993d3=document[_0x326cac(0x16d)](_0x326cac(0x26d));_0x4993d3['className']=_0x326cac(0x31f)+_0x38b376(_0x3c1552[_0x326cac(0x331)]['status'])+'\x20bg-light-subtle\x20border\x20border-'+_0x38b376(_0x3c1552[_0x326cac(0x331)]['status']),_0x4993d3['setAttribute'](_0x326cac(0x2bf),_0x3c1552['orderId']);const _0x5e1d0e=new Date()[_0x326cac(0x241)](),_0x210b2b=new Date()[_0x326cac(0x32a)](),_0x55ac1c=new Date()['getDay'](),_0x1e76f6=0xa===_0x5e1d0e&&_0x210b2b>=0x0||0x5===_0x55ac1c&&0x16===_0x5e1d0e&&_0x210b2b<=0x32||0x0===_0x55ac1c&&0x16===_0x5e1d0e&&_0x210b2b<=0x32||0x5!==_0x55ac1c&&0x0!==_0x55ac1c&&0x15===_0x5e1d0e&&_0x210b2b<=0x32||_0x5e1d0e>0xa&&_0x5e1d0e<0x15;let _0x377af6=_0x326cac(0x202)!==_0x3c1552['OrderData'][_0x326cac(0x2a5)]&&_0x326cac(0x216)!==_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)]&&'ondelivery'!==_0x3c1552[_0x326cac(0x331)]['status']&&_0x326cac(0x1e6)!==_0x3c1552[_0x326cac(0x331)]['status'];return _0x377af6=_0x377af6&&_0x1e76f6,_0x4993d3[_0x326cac(0x27a)]=_0x326cac(0x247)+function(_0x1c066a,_0x5b09ce){const _0x5fae2=_0x326cac;switch(_0x1c066a){case _0x5fae2(0x202):return _0x5fae2(0x23e);case _0x5fae2(0x216):return _0x5fae2(0x259)===_0x5b09ce?'Confirmé\x20pour\x20retrait.':'Confirmé.';case _0x5fae2(0x318):return _0x5fae2(0x253);case _0x5fae2(0x1b2):return _0x5fae2(0x252);case _0x5fae2(0x1e6):return'Annulé.';default:return _0x5fae2(0x1c2);}}(_0x3c1552[_0x326cac(0x331)]['status'],_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)])+'\x0a'+(_0x377af6?_0x326cac(0x160)+_0x3c1552['orderId']+_0x326cac(0x255):_0x326cac(0x33c))+_0x326cac(0x2c4)+(_0x326cac(0x202)===_0x3c1552[_0x326cac(0x331)]['status']?_0x326cac(0x344)+_0x38b376(_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)])+'-subtle\x20text-danger\x20rounded\x20opacity-75\x22>Votre\x20commande\x20est\x20en\x20cours\x20de\x20confirmation.\x20Les\x20commandes\x20passées\x20pendant\x20les\x20heures\x20ouvrables\x20sont\x20confirmées\x20en\x20quelques\x20secondes.</div>':'')+'\x0a'+('confirmed'===_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)]?'<div\x20class=\x22p-2\x20mb-2\x20bg-'+_0x38b376(_0x3c1552['OrderData'][_0x326cac(0x2a5)])+_0x326cac(0x320)+function(_0x2c26a7){const _0xb3d2d3=_0x326cac;return'emporter'===_0x2c26a7?_0xb3d2d3(0x1ae):_0xb3d2d3(0x179);}(_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)])+'</div>':'')+'\x0a'+(_0x326cac(0x318)===_0x3c1552['OrderData'][_0x326cac(0x2a5)]?_0x326cac(0x344)+_0x38b376(_0x3c1552['OrderData'][_0x326cac(0x2a5)])+_0x326cac(0x228):'')+'\x0a'+(_0x326cac(0x1e6)===_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)]?_0x326cac(0x344)+_0x38b376(_0x3c1552['OrderData'][_0x326cac(0x2a5)])+_0x326cac(0x1ad):'')+'\x0a<p\x20class=\x27card-title\x20text-end\x27>Date\x20de\x20commande:\x20'+_0x3c1552[_0x326cac(0x331)]['date']+_0x326cac(0x220)+(_0x326cac(0x259)===_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)]?_0x326cac(0x28f):_0x326cac(0x23c))+_0x326cac(0x30c)+(_0x3c1552[_0x326cac(0x331)]['requestedFor']?_0x326cac(0x282)+_0x3c1552[_0x326cac(0x331)][_0x326cac(0x30a)]+_0x326cac(0x301):'')+'\x0a'+_0x36ab7d+'\x0a'+(_0x326cac(0x162)===_0x3c1552['OrderData'][_0x326cac(0x2c0)]?'<p\x20class=\x27card-subtitle\x20text-end\x20text-muted\x27>Frais\x20de\x20livraison:\x202.00\x20CHF</p>':'')+_0x326cac(0x188)+_0x3c1552[_0x326cac(0x331)]['price']+'\x20CHF</p>\x0a'+('emporter'===_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)]&&_0x326cac(0x1b2)!==_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)]?_0x326cac(0x280):'')+'\x0a</div>\x0a',_0x4993d3;}(_0xc6ac1d);_0x8db546[_0x19773c(0x15b)](_0x238232);}),_0x1bfb86&&!_0x5dfec8?_0x5dfec8=setInterval(_0x21da7d,0x3a98):!_0x1bfb86&&_0x5dfec8&&(clearInterval(_0x5dfec8),_0x5dfec8=null),localStorage[_0x1e7e10(0x281)](_0x1e7e10(0x32d),JSON['stringify'](_0x2f3d6c)),_0x2f3d6c;})[_0x19e656(0x1a3)](_0x457009=>{const _0x5988ed=_0x19e656;console[_0x5988ed(0x2b6)](_0x5988ed(0x2a4),_0x457009);});}function _0x1583ba(_0x58a89b,_0x49cbd9){const _0x415876=_0x537fe3;let _0xea8a82='';return _0x415876(0x213)!=typeof _0x58a89b||null===_0x58a89b||Array[_0x415876(0x258)](_0x58a89b)||(_0x58a89b=Object['values'](_0x58a89b)),Array[_0x415876(0x258)](_0x58a89b)&&_0x58a89b[_0x415876(0x315)](_0x5638f3=>{const _0x288065=_0x415876;let _0x50559b='';switch(_0x49cbd9){case'Tacos':_0x50559b=_0x288065(0x164)+_0x5638f3[_0x288065(0x28b)][_0x288065(0x208)](_0x1095a3=>{const _0xb38fd3=_0x288065,_0x1e5a7c=_0x1095a3['quantity']&&_0x1095a3[_0xb38fd3(0x261)]>0x1?'\x20x'+_0x1095a3[_0xb38fd3(0x261)]:'';return _0x1095a3[_0xb38fd3(0x1f1)]+_0x1e5a7c;})[_0x288065(0x1a6)](',\x20')+'\x20</em>\x20<br>-\x20<strong>Garnitures:</strong><em>\x20'+_0x5638f3[_0x288065(0x22e)][_0x288065(0x208)](_0xf6ab5a=>_0xf6ab5a[_0x288065(0x1f1)])[_0x288065(0x1a6)](',\x20')+'\x20</em>\x20<br>-\x20<strong>Sauces:</strong><em>\x20'+_0x5638f3[_0x288065(0x2bc)][_0x288065(0x208)](_0x229d4b=>_0x229d4b[_0x288065(0x1f1)])['join'](',\x20')+_0x288065(0x176),_0x5638f3[_0x288065(0x215)]&&(_0x50559b+='<br>-\x20<strong>Remarque:</strong>\x20<em>'+_0x5638f3[_0x288065(0x215)]+_0x288065(0x2e4));break;case'Extras':let _0x4210f5='';if(_0x5638f3['free_sauces']&&Array[_0x288065(0x258)](_0x5638f3['free_sauces'])&&_0x5638f3[_0x288065(0x260)][_0x288065(0x337)]>0x0){const _0x6f2e01=_0x5638f3[_0x288065(0x260)]['filter'](_0x3a319a=>_0x3a319a[_0x288065(0x1f1)])[_0x288065(0x208)](_0x1b5913=>_0x1b5913[_0x288065(0x1f1)]);_0x6f2e01[_0x288065(0x337)]>0x0&&(_0x4210f5=_0x288065(0x249)+_0x6f2e01['join'](',\x20')+_0x288065(0x2e4));}else _0x5638f3[_0x288065(0x324)]&&_0x5638f3[_0x288065(0x324)][_0x288065(0x1f1)]&&(_0x4210f5=_0x288065(0x1ec)+_0x5638f3['free_sauce'][_0x288065(0x1f1)]+_0x288065(0x2e4));_0x50559b=_0x4210f5;break;default:_0x50559b='';}_0xea8a82+=_0x288065(0x2a1)+_0x5638f3[_0x288065(0x261)]+_0x288065(0x343)+_0x5638f3[_0x288065(0x1f1)]+'\x20-\x20'+_0x5638f3[_0x288065(0x2c5)]+'\x20CHF\x20'+_0x50559b+_0x288065(0x222);}),_0xea8a82;}function _0x38b376(_0x1ee734){const _0x29bf1a=_0x537fe3;switch(_0x1ee734){case _0x29bf1a(0x202):default:return _0x29bf1a(0x1c2);case _0x29bf1a(0x216):case _0x29bf1a(0x318):return'success';case _0x29bf1a(0x1b2):return _0x29bf1a(0x23b);case _0x29bf1a(0x1e6):return'light-subtle';}}window[_0x537fe3(0x284)]=function(_0x4c0389){const _0x29b15b=_0x537fe3,_0x46a4f7=JSON[_0x29b15b(0x32b)](localStorage['getItem'](_0x29b15b(0x32d)))['find'](_0x319017=>_0x319017[_0x29b15b(0x231)]==_0x4c0389);if(!_0x46a4f7)return void alert(_0x29b15b(0x16e));const _0x19aba6=_0x47aee6(),_0x2a5f05=document[_0x29b15b(0x268)](_0x29b15b(0x2ea)+_0x4c0389+_0x29b15b(0x1a4));_0x2a5f05[_0x29b15b(0x1de)]=!0x0,fetch('ajax/restore_order.php',{'method':_0x29b15b(0x1c8),'headers':{'X-CSRF-Token':_0x19aba6},'body':JSON[_0x29b15b(0x15d)]({'order':_0x46a4f7})})[_0x29b15b(0x2be)](_0x12f637=>{const _0xe8fdb5=_0x29b15b;if(!_0x12f637['ok'])throw 0x193===_0x12f637[_0xe8fdb5(0x2a5)]&&alert(_0xe8fdb5(0x297)),new Error(_0xe8fdb5(0x31b));return _0x12f637['json']();})[_0x29b15b(0x2be)](_0x4a7f29=>{const _0x305fa2=_0x29b15b;if(_0x305fa2(0x28a)===_0x4a7f29['status']||'warning'===_0x4a7f29[_0x305fa2(0x2a5)]){const _0x4bad2f=new bootstrap['Modal'](document[_0x305fa2(0x239)](_0x305fa2(0x18e))),_0x12c329=document[_0x305fa2(0x239)]('successModalBody');if(_0x305fa2(0x238)===_0x4a7f29['status']){let _0x5dd7f8='';_0x4a7f29[_0x305fa2(0x29b)]&&_0x4a7f29['out_of_stock_items'][_0x305fa2(0x337)]>0x0&&(_0x5dd7f8='<div\x20class=\x22alert\x20alert-warning\x20text-start\x20mx-auto\x22\x20style=\x22max-width:\x20500px;\x20background-color:\x20#fff3cd;\x20border-left:\x204px\x20solid\x20#ffc107;\x22><ul\x20style=\x22list-style:\x20none;\x20padding-left:\x200;\x20margin-bottom:\x200;\x22>',_0x4a7f29['out_of_stock_items'][_0x305fa2(0x315)](function(_0xb2dbd0){const _0x4e7032=_0x305fa2;_0x5dd7f8+='<li\x20style=\x22padding:\x208px\x200;\x20border-bottom:\x201px\x20solid\x20#ffeaa7;\x22><i\x20class=\x22fa\x20fa-times-circle\x20text-danger\x20me-2\x22></i><strong>'+_0xb2dbd0+_0x4e7032(0x1e5);}),_0x5dd7f8+=_0x305fa2(0x16b)),_0x12c329[_0x305fa2(0x27a)]='<div\x20class=\x22text-center\x22\x20style=\x22padding:\x2020px;\x22><div\x20class=\x22d-flex\x20justify-content-center\x20align-items-center\x20mb-4\x22\x20style=\x22height:\x20100px;\x22><div\x20style=\x22width:\x20100px;\x20height:\x20100px;\x20border-radius:\x2050%;\x20background:\x20linear-gradient(135deg,\x20#ffeaa7\x200%,\x20#fdcb6e\x20100%);\x20display:\x20flex;\x20align-items:\x20center;\x20justify-content:\x20center;\x20box-shadow:\x200\x204px\x2015px\x20rgba(253,\x20203,\x20110,\x200.4);\x22><i\x20class=\x22fa\x20fa-exclamation-triangle\x22\x20style=\x22color:\x20#fff;\x20font-size:\x2050px;\x22></i></div></div><h4\x20class=\x22mb-3\x22\x20style=\x22color:\x20#e17055;\x20font-weight:\x20600;\x22>Certains\x20produits\x20ne\x20sont\x20pas\x20disponibles</h4><p\x20class=\x22mb-4\x22\x20style=\x22color:\x20#636e72;\x20font-size:\x2015px;\x22>Les\x20produits\x20suivants\x20ne\x20sont\x20temporairement\x20pas\x20disponibles\x20et\x20n\x27ont\x20pas\x20été\x20ajoutés\x20à\x20votre\x20panier:</p>'+_0x5dd7f8+_0x305fa2(0x1c7),_0x4bad2f[_0x305fa2(0x14c)](),document[_0x305fa2(0x239)](_0x305fa2(0x1dc))[_0x305fa2(0x329)](_0x305fa2(0x274),function(){const _0x37f739=_0x305fa2;_0x4bad2f[_0x37f739(0x1d0)](),localStorage[_0x37f739(0x281)](_0x37f739(0x2e7),_0x37f739(0x251)),window[_0x37f739(0x186)][_0x37f739(0x27b)]();});}else{_0x12c329['innerHTML']=_0x305fa2(0x25b),_0x4bad2f[_0x305fa2(0x14c)]();let _0x335b7a=0x3;const _0x393272=document['getElementById']('countdown'),_0x2744f3=setInterval(()=>{const _0x2f80b6=_0x305fa2;_0x335b7a--,_0x393272[_0x2f80b6(0x1b8)]=_0x335b7a,0x0===_0x335b7a&&(clearInterval(_0x2744f3),_0x4bad2f['hide'](),localStorage[_0x2f80b6(0x281)]('openOrderModal',_0x2f80b6(0x251)),window[_0x2f80b6(0x186)][_0x2f80b6(0x27b)]());},0x3e8);}}else alert(_0x305fa2(0x1bd)),_0x2a5f05[_0x305fa2(0x1de)]=!0x1;})[_0x29b15b(0x1a3)](_0x5ea52e=>{const _0x157394=_0x29b15b;console['error']('Error:',_0x5ea52e),alert(_0x157394(0x1bd)),_0x2a5f05[_0x157394(0x1de)]=!0x1;});},document['addEventListener'](_0x537fe3(0x2d9),function(){const _0x151333=_0x537fe3;if(_0x151333(0x251)===localStorage[_0x151333(0x2b2)]('openOrderModal')){localStorage[_0x151333(0x1fc)]('openOrderModal'),new bootstrap[(_0x151333(0x173))](document[_0x151333(0x239)]('orderModal'))[_0x151333(0x14c)]();var _0x256d78=_0x47aee6();fetch(_0x151333(0x2f0),{'method':_0x151333(0x1c8),'headers':{'Content-Type':_0x151333(0x1ba)},'body':'csrf_token='+encodeURIComponent(_0x256d78)})[_0x151333(0x2be)](_0x5ae98f=>{const _0x548ab2=_0x151333;if(!_0x5ae98f['ok'])throw 0x193===_0x5ae98f[_0x548ab2(0x2a5)]&&console[_0x548ab2(0x2e2)](_0x548ab2(0x335)),new Error(_0x548ab2(0x207));return _0x5ae98f[_0x548ab2(0x2ca)]();})[_0x151333(0x2be)](_0x47e711=>{const _0xc0240a=_0x151333;document[_0xc0240a(0x268)](_0xc0240a(0x1b4))[_0xc0240a(0x27a)]=_0x47e711;})['catch'](_0x1981d3=>console[_0x151333(0x2b6)](_0x151333(0x229),_0x1981d3));}}),document[_0x537fe3(0x293)](_0x537fe3(0x309))[_0x537fe3(0x315)](_0x227261=>{const _0x4ae9d2=_0x537fe3;_0x227261[_0x4ae9d2(0x329)](_0x4ae9d2(0x274),function(){const _0x5d7177=_0x4ae9d2,_0x176c22=this['dataset'][_0x5d7177(0x24c)],_0x52bd76={'activeSection':this[_0x5d7177(0x1a5)][_0x5d7177(0x17d)](_0x5d7177(0x23a))?null:_0x176c22,'timestamp':new Date()[_0x5d7177(0x1d2)]()};localStorage[_0x5d7177(0x281)](_0x5d7177(0x2cd),JSON['stringify'](_0x52bd76));});}),document[_0x537fe3(0x329)]('DOMContentLoaded',function(){const _0x25c37c=_0x537fe3,_0x45f0a7=localStorage['getItem'](_0x25c37c(0x2cd));if(_0x45f0a7){const {activeSection:_0x164a25,timestamp:_0x3d64d9}=JSON['parse'](_0x45f0a7);if(new Date()[_0x25c37c(0x1d2)]()-_0x3d64d9<0x36ee80&&_0x164a25){const _0x84168f=document[_0x25c37c(0x268)](_0x164a25);_0x84168f&&new bootstrap['Collapse'](_0x84168f,{'toggle':!0x1})[_0x25c37c(0x14c)]();}else localStorage[_0x25c37c(0x1fc)](_0x25c37c(0x2cd));}}),document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x32ea22=_0x537fe3;document[_0x32ea22(0x1f6)][_0x32ea22(0x329)](_0x32ea22(0x274),function(_0x1ac9d0){const _0x21e19c=_0x32ea22;_0x1ac9d0[_0x21e19c(0x2dc)][_0x21e19c(0x341)](_0x21e19c(0x20c))&&_0x386ce7('increaseQuantity',_0x1ac9d0[_0x21e19c(0x2dc)][_0x21e19c(0x2c8)][_0x21e19c(0x27e)]),_0x1ac9d0[_0x21e19c(0x2dc)][_0x21e19c(0x341)](_0x21e19c(0x2f3))&&_0x386ce7('decreaseQuantity',_0x1ac9d0[_0x21e19c(0x2dc)][_0x21e19c(0x2c8)][_0x21e19c(0x27e)]);});});var _0x55487c,_0x112180,_0x23890d,_0x52e29c=_0x47aee6();function _0x386ce7(_0xe0fea4,_0x1ffe13){const _0x4995e1=_0x537fe3;var _0x3e0b41=new XMLHttpRequest();_0x3e0b41[_0x4995e1(0x2cf)](_0x4995e1(0x1c8),_0x4995e1(0x2f6),!0x0),_0x3e0b41[_0x4995e1(0x206)](_0x4995e1(0x19a),_0x4995e1(0x1ba)),_0x3e0b41['setRequestHeader']('X-CSRF-Token',_0x52e29c),_0x3e0b41[_0x4995e1(0x2b9)]=function(){const _0x19691b=_0x4995e1;if(0xc8===_0x3e0b41['status']){_0x5d92f3();var _0x2e70e3=JSON[_0x19691b(0x32b)](this[_0x19691b(0x198)]);if(_0x19691b(0x28a)===_0x2e70e3[_0x19691b(0x2a5)]){var _0x9350be=document[_0x19691b(0x268)](_0x19691b(0x152)+_0x1ffe13+'\x20.quantity-input');_0x9350be?(_0x9350be[_0x19691b(0x300)]=_0x2e70e3[_0x19691b(0x261)],_0x43c433()):console['error'](_0x19691b(0x25e)+_0x1ffe13);}else alert(_0x19691b(0x30b));}else console[_0x19691b(0x2b6)](_0x19691b(0x25a)+_0x3e0b41['status']+':\x20'+_0x3e0b41[_0x19691b(0x193)]);},_0x3e0b41[_0x4995e1(0x158)](_0x4995e1(0x1d8)+_0xe0fea4+'&index='+_0x1ffe13);}function _0x3fc20a(_0x4143f7){const _0x3434b0=_0x537fe3;[..._0x55487c,..._0x112180][_0x3434b0(0x315)](_0x5b992b=>_0x5b992b[_0x3434b0(0x1de)]=!0x1);let _0xe30583=0x0;switch(_0x4143f7){case _0x3434b0(0x2ba):_0xe30583=0x1;break;case _0x3434b0(0x2b0):_0xe30583=0x2;break;case'tacos_L_mixte':case _0x3434b0(0x212):_0xe30583=0x3;break;case _0x3434b0(0x317):_0xe30583=0x4;break;case _0x3434b0(0x30e):_0xe30583=0x5;break;default:return void[..._0x55487c,..._0x112180][_0x3434b0(0x315)](_0x2652ae=>_0x2652ae[_0x3434b0(0x1de)]=!0x0);}!function(_0x102f92){const _0x5a684a=_0x3434b0;let _0x20c301=[..._0x55487c][_0x5a684a(0x2fd)](_0x2547c4=>_0x2547c4[_0x5a684a(0x1eb)])[_0x5a684a(0x337)];_0x55487c['forEach'](_0x710035=>{const _0x1d99da=_0x5a684a;_0x710035[_0x1d99da(0x1de)]=_0x20c301>=_0x102f92&&!_0x710035[_0x1d99da(0x1eb)];}),_0x55487c[_0x5a684a(0x315)](_0x1dc42b=>{_0x1dc42b['addEventListener']('change',()=>{const _0x354189=a0_0x43d4;let _0x66fd9d=[..._0x55487c][_0x354189(0x2fd)](_0x2de898=>_0x2de898['checked'])[_0x354189(0x337)];_0x55487c[_0x354189(0x315)](_0x52101d=>{const _0x473dff=_0x354189;_0x52101d[_0x473dff(0x1de)]=_0x66fd9d>=_0x102f92&&!_0x52101d[_0x473dff(0x1eb)];});});});}(_0xe30583),function(_0x24c6e8){const _0xaae1fa=_0x3434b0;let _0x5d7f15=[..._0x112180][_0xaae1fa(0x2fd)](_0x19bee1=>_0x19bee1[_0xaae1fa(0x1eb)])[_0xaae1fa(0x337)];_0x112180['forEach'](_0x5ece24=>{const _0x36a4c9=_0xaae1fa;_0x5ece24[_0x36a4c9(0x1de)]=_0x5d7f15>=_0x24c6e8&&!_0x5ece24['checked'];}),_0x112180[_0xaae1fa(0x315)](_0x1dfacb=>{const _0x4cca5b=_0xaae1fa;_0x1dfacb[_0x4cca5b(0x329)]('change',()=>{const _0x3f3c90=_0x4cca5b;let _0x379f7a=[..._0x112180][_0x3f3c90(0x2fd)](_0xbd870d=>_0xbd870d[_0x3f3c90(0x1eb)])[_0x3f3c90(0x337)];_0x112180[_0x3f3c90(0x315)](_0x551a20=>{const _0x5bd7cd=_0x3f3c90;_0x551a20[_0x5bd7cd(0x1de)]=_0x379f7a>=_0x24c6e8&&!_0x551a20[_0x5bd7cd(0x1eb)];});});});}(0x3);}function _0x20c88e(_0x5c8afd,_0x6f4a63,_0x3dd0cd,_0x48be50,_0x56ce49=null,_0x47d502='',_0x4c04dd=null){const _0x27c2db=_0x537fe3;var _0x44207a=_0x47aee6();const _0x349927={'id':_0x5c8afd,'name':_0x6f4a63,'price':_0x3dd0cd,'quantity':_0x48be50,'free_sauce':_0x56ce49?{'id':_0x56ce49,'name':_0x47d502,'price':0x0}:void 0x0,'free_sauces':_0x4c04dd};fetch(_0x27c2db(0x305),{'method':_0x27c2db(0x1c8),'headers':{'X-CSRF-Token':_0x44207a},'body':JSON[_0x27c2db(0x15d)](_0x349927)})[_0x27c2db(0x2be)](_0x597efc=>_0x597efc[_0x27c2db(0x290)]())[_0x27c2db(0x2be)](_0x167028=>{_0x43c433();})[_0x27c2db(0x1a3)](_0x3a4f57=>console[_0x27c2db(0x2b6)](_0x27c2db(0x24b),_0x3a4f57));}function _0x52fe89(){const _0xf8ac58=_0x537fe3;var _0x1ffc2e=_0x47aee6();fetch(_0xf8ac58(0x196),{'method':_0xf8ac58(0x1c8),'headers':{'X-CSRF-Token':_0x1ffc2e}})[_0xf8ac58(0x2be)](_0x487ae2=>{const _0x57d896=_0xf8ac58;if(!_0x487ae2['ok'])throw 0x193===_0x487ae2[_0x57d896(0x2a5)]&&console[_0x57d896(0x2e2)]('SD\x20REFRESH'),new Error('Network\x20response\x20was\x20not\x20ok');return _0x487ae2[_0x57d896(0x290)]();})[_0xf8ac58(0x2be)](_0x2c48ff=>{const _0x526a3c=_0xf8ac58;Object[_0x526a3c(0x177)](_0x2c48ff)[_0x526a3c(0x315)](([_0x4df84d,_0x40e29f])=>{const _0xeb8742=_0x526a3c,_0xbe9039=_0x40e29f[_0xeb8742(0x30d)],_0x39e1a9=_0x40e29f[_0xeb8742(0x178)];let _0x252353;switch(_0x4df84d){case'tacos':_0x252353=_0xeb8742(0x240);break;case _0xeb8742(0x2b8):_0x252353=_0xeb8742(0x33e);break;case'boissons':_0x252353='selectDrinks';break;case'desserts':_0x252353='selectDesserts';break;default:return void console[_0xeb8742(0x2b6)](_0xeb8742(0x2aa),_0x4df84d);}const _0x33e9d8=document['querySelector']('#'+_0x252353+_0xeb8742(0x31e));if(_0x33e9d8){if(_0xbe9039>0x0){const _0x2f1423=_0xbe9039>0x1?_0xeb8742(0x257):_0xeb8742(0x254);_0x33e9d8[_0xeb8742(0x1b8)]=_0xbe9039+'\x20'+_0x2f1423+_0xeb8742(0x21a)+_0x39e1a9+_0xeb8742(0x1ce),_0x33e9d8[_0xeb8742(0x2cb)][_0xeb8742(0x159)]='';}else _0x33e9d8['style'][_0xeb8742(0x159)]=_0xeb8742(0x204);}});})[_0xf8ac58(0x1a3)](_0x16350a=>console[_0xf8ac58(0x2b6)](_0xf8ac58(0x24b),_0x16350a));}function _0x43c433(){const _0x24c6f3=_0x537fe3;var _0x191cd9=_0x47aee6();fetch('ajax/cs.php',{'method':_0x24c6f3(0x1c8),'headers':{'Content-Type':_0x24c6f3(0x1ba),'X-CSRF-Token':_0x191cd9}})[_0x24c6f3(0x2be)](_0x8b99a9=>{const _0x5367f1=_0x24c6f3;if(!_0x8b99a9['ok'])throw 0x193===_0x8b99a9[_0x5367f1(0x2a5)]&&console['log'](_0x5367f1(0x296)),new Error(_0x5367f1(0x182));return _0x8b99a9[_0x5367f1(0x290)]();})[_0x24c6f3(0x2be)](_0x467783=>{const _0x63208c=_0x24c6f3;document['getElementById'](_0x63208c(0x23d))[_0x63208c(0x27a)]=_0x467783[_0x63208c(0x2f5)],_0x52fe89();})[_0x24c6f3(0x1a3)](_0x4b3c99=>console[_0x24c6f3(0x2b6)](_0x24c6f3(0x2b3),_0x4b3c99));}function _0x9e04ab(_0x48bdee,_0x388049){const _0x133270=_0x537fe3;var _0x40cb0f=[_0x133270(0x1cc),_0x133270(0x28c),'merguez',_0x133270(0x246),_0x133270(0x31d),_0x133270(0x1b9)],_0xe84a35=[_0x133270(0x1c5),_0x133270(0x21c),_0x133270(0x1e1),_0x133270(0x279)],_0x517c75=['cheddar',_0x133270(0x327),_0x133270(0x334)];'tacos_BOWL'===_0x48bdee?(_0x40cb0f['concat'](_0xe84a35)['forEach'](function(_0x453bc0){const _0x42c498=_0x133270,_0x1339d1=document[_0x42c498(0x268)](_0x42c498(0x26a)+_0x453bc0+'\x22]');_0x1339d1&&!_0x1339d1[_0x42c498(0x1eb)]&&(_0x1339d1[_0x42c498(0x1de)]=!0x1);}),_0x40cb0f[_0x133270(0x22b)](_0xe84a35)[_0x133270(0x315)](function(_0x5df07b){const _0x270cf8=_0x133270;document[_0x270cf8(0x239)](_0x388049+_0x5df07b+_0x270cf8(0x2ae))['style'][_0x270cf8(0x159)]=_0x270cf8(0x31c);}),_0x517c75[_0x133270(0x315)](function(_0x26f514){const _0x4ae888=_0x133270;document[_0x4ae888(0x239)](_0x388049+_0x26f514+'_div')['style'][_0x4ae888(0x159)]='none';}),document[_0x133270(0x239)](_0x388049+_0x133270(0x2a8))[_0x133270(0x2cb)][_0x133270(0x159)]=_0x133270(0x31c)):(_0x40cb0f[_0x133270(0x22b)](_0xe84a35)[_0x133270(0x315)](function(_0x14a28a){const _0x1edaae=_0x133270;document['getElementById'](_0x388049+_0x14a28a+_0x1edaae(0x2ae))[_0x1edaae(0x2cb)][_0x1edaae(0x159)]=_0x1edaae(0x31c);}),_0x517c75[_0x133270(0x315)](function(_0x2da752){const _0x162d0c=_0x133270;document[_0x162d0c(0x239)](_0x388049+_0x2da752+_0x162d0c(0x2ae))[_0x162d0c(0x2cb)][_0x162d0c(0x159)]=_0x162d0c(0x31c);}),document['getElementById'](_0x388049+_0x133270(0x2a8))[_0x133270(0x2cb)]['display']='none');}function _0xc3c9b1(){const _0x246b2f=_0x537fe3;document['getElementById']('tacosForm')[_0x246b2f(0x2e9)](),[..._0x55487c,..._0x112180,..._0x23890d][_0x246b2f(0x315)](_0x4853ba=>{const _0x29e737=_0x246b2f;_0x4853ba[_0x29e737(0x1eb)]=!0x1,_0x4853ba[_0x29e737(0x1de)]=!0x1;});}function _0x5d92f3(){const _0x1b3c75=_0x537fe3;0x0===$(_0x1b3c75(0x270))[_0x1b3c75(0x2e6)]()[_0x1b3c75(0x337)]?($('#product-messages')[_0x1b3c75(0x2c6)](_0x1b3c75(0x2ac)),$(_0x1b3c75(0x2a7))['remove']()):$(_0x1b3c75(0x2e3))[_0x1b3c75(0x2c6)]('<div\x20class=\x22bg-danger\x20rounded\x20text-light\x20p-2\x22\x20role=\x22alert\x22><i\x20class=\x22fa-solid\x20fa-chevron-down\x22></i>\x20Tacos\x20dans\x20votre\x20panier</div>'),$(_0x1b3c75(0x1c0))[_0x1b3c75(0x1d9)](function(_0x159822){const _0xdff9b1=_0x1b3c75;$(this)[_0xdff9b1(0x2fb)]('id','tacos-'+_0x159822),$(this)['attr'](_0xdff9b1(0x20e),_0x159822),$(this)[_0xdff9b1(0x244)](_0xdff9b1(0x218))[_0xdff9b1(0x2fb)](_0xdff9b1(0x20e),_0x159822);});}function _0x2b3ace(){const _0x3f64f1=_0x537fe3;var _0x239238=_0x47aee6();$[_0x3f64f1(0x1d3)]({'type':_0x3f64f1(0x1c8),'url':_0x3f64f1(0x2f6),'headers':{'X-CSRF-Token':_0x239238},'data':{'loadProducts':!0x0},'success':function(_0x3e6ff8){const _0x5c19a5=_0x3f64f1;$(_0x5c19a5(0x270))['html'](_0x3e6ff8),_0x5d92f3(),_0x43c433();},'error':function(){const _0x1ac6c9=_0x3f64f1;location[_0x1ac6c9(0x27b)]();}});}document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x374dec=_0x537fe3;document[_0x374dec(0x239)](_0x374dec(0x2f7))[_0x374dec(0x329)](_0x374dec(0x274),function(_0x2201a4){const _0x10781c=_0x374dec,_0xd0620c=_0x2201a4[_0x10781c(0x2dc)][_0x10781c(0x219)]('.edit-tacos');if(_0xd0620c){_0x2201a4[_0x10781c(0x2f1)]();const _0x3ea2d6=_0xd0620c[_0x10781c(0x201)]('data-index'),_0x290c87=_0x47aee6();document[_0x10781c(0x239)]('editIndex')[_0x10781c(0x300)]=_0x3ea2d6,fetch(_0x10781c(0x14f),{'method':_0x10781c(0x1c8),'headers':{'X-CSRF-Token':_0x290c87,'Content-Type':'application/x-www-form-urlencoded'},'body':_0x10781c(0x20b)+_0x3ea2d6})[_0x10781c(0x2be)](_0x49574f=>{const _0x57ed16=_0x10781c;if(!_0x49574f['ok'])throw 0x193===_0x49574f[_0x57ed16(0x2a5)]&&console[_0x57ed16(0x2e2)](_0x57ed16(0x299)),new Error(_0x57ed16(0x166));return _0x49574f[_0x57ed16(0x290)]();})[_0x10781c(0x2be)](_0x32a4f1=>{const _0x12b5bb=_0x10781c;if(_0x12b5bb(0x28a)===_0x32a4f1[_0x12b5bb(0x2a5)]){const {taille:_0x17960c,viande:_0xf20883,garniture:_0x5a3a4d,sauce:_0x128092,tacosNote:_0x49431e}=_0x32a4f1[_0x12b5bb(0x21b)];console[_0x12b5bb(0x2e2)]('Loaded\x20tacos\x20data:',_0x32a4f1[_0x12b5bb(0x21b)]),console[_0x12b5bb(0x2e2)](_0x12b5bb(0x2a3),_0xf20883),document['getElementById'](_0x12b5bb(0x18f))['value']=_0x17960c,document['getElementById'](_0x12b5bb(0x2f4))['value']=_0x17960c,document[_0x12b5bb(0x239)](_0x12b5bb(0x330))[_0x12b5bb(0x300)]=_0x49431e,document[_0x12b5bb(0x293)](_0x12b5bb(0x194))['forEach'](_0x5342e4=>{const _0x22fa9a=_0x12b5bb;_0x5342e4[_0x22fa9a(0x1eb)]=!0x1;}),function(_0x5240e1,_0x2c8c27,_0xd03c5c,_0x3f59da){const _0xa03818=_0x12b5bb;document['querySelectorAll'](_0xa03818(0x194))[_0xa03818(0x315)](_0x4d1b11=>{const _0x11f03f=_0xa03818;_0x4d1b11['checked']=!0x1,_0x4d1b11[_0x11f03f(0x1de)]=!0x1;}),document[_0xa03818(0x293)](_0xa03818(0x197))[_0xa03818(0x315)](_0x21eefc=>{const _0x19ccf3=_0xa03818;_0x21eefc['classList'][_0x19ccf3(0x165)](_0x19ccf3(0x189));const _0x4038c2=_0x21eefc[_0x19ccf3(0x268)]('.meat-quantity-input');_0x4038c2&&(_0x4038c2[_0x19ccf3(0x300)]=0x1,_0x4038c2[_0x19ccf3(0x1de)]=!0x0);});let _0x54deb5=0x1;switch(_0x3f59da){case _0xa03818(0x2ba):_0x54deb5=0x1;break;case _0xa03818(0x1ed):case _0xa03818(0x212):_0x54deb5=0x3;break;case'tacos_XXL':_0x54deb5=0x4;break;case _0xa03818(0x30e):_0x54deb5=0x5;}_0x5240e1[_0xa03818(0x315)](_0xe764fa=>{const _0x5c2a7c=_0xa03818,_0x2af82f=document[_0x5c2a7c(0x268)]('#tacosEditForm\x20input[name=\x22viande[]\x22][value=\x22'+_0xe764fa[_0x5c2a7c(0x1aa)]+'\x22]');if(_0x2af82f&&(_0x2af82f[_0x5c2a7c(0x1eb)]=!0x0,_0x54deb5>0x1)){const _0x1b776e=_0x2af82f[_0x5c2a7c(0x219)](_0x5c2a7c(0x2d0));if(_0x1b776e){const _0x568555=_0x1b776e['querySelector'](_0x5c2a7c(0x2c1)),_0x389096=_0x1b776e['querySelector'](_0x5c2a7c(0x288));_0x568555&&_0x389096&&(_0x568555[_0x5c2a7c(0x1a5)]['remove'](_0x5c2a7c(0x189)),_0x389096[_0x5c2a7c(0x300)]=_0xe764fa[_0x5c2a7c(0x261)]||0x1,_0x389096[_0x5c2a7c(0x1de)]=!0x1);}}}),_0x2c8c27[_0xa03818(0x315)](_0x122bf2=>{const _0x1d1233=_0xa03818,_0x49b28c=document['querySelector'](_0x1d1233(0x264)+_0x122bf2[_0x1d1233(0x1aa)]+'\x22]');_0x49b28c&&(_0x49b28c[_0x1d1233(0x1eb)]=!0x0);}),_0xd03c5c[_0xa03818(0x315)](_0x4de63d=>{const _0x11dd0c=_0xa03818,_0x2f3350=document[_0x11dd0c(0x268)]('#tacosEditForm\x20input[name=\x22sauce[]\x22][value=\x22'+_0x4de63d[_0x11dd0c(0x1aa)]+'\x22]');_0x2f3350&&(_0x2f3350[_0x11dd0c(0x1eb)]=!0x0);}),_0x3fc20a(_0x3f59da);}(_0xf20883,_0x5a3a4d,_0x128092,_0x17960c),new bootstrap[(_0x12b5bb(0x173))](document['getElementById'](_0x12b5bb(0x33b)))['show']();}else console['error'](_0x12b5bb(0x269),_0x32a4f1[_0x12b5bb(0x2f5)]),console[_0x12b5bb(0x2e2)](_0x12b5bb(0x1b1));})['catch'](_0x452342=>console[_0x10781c(0x2b6)]('Error:',_0x452342));}});}),document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x9fb371=_0x537fe3;document['getElementById']('tacosEditForm')[_0x9fb371(0x329)]('submit',function(_0x3eff30){const _0x22759e=_0x9fb371;_0x3eff30['preventDefault']();const _0x2d852e=document[_0x22759e(0x239)](_0x22759e(0x18f))['value'],_0x58a803=document[_0x22759e(0x293)](_0x22759e(0x2fc)),_0x414cb3=document[_0x22759e(0x293)](_0x22759e(0x26b)),_0x1cb967=document[_0x22759e(0x293)](_0x22759e(0x1b0));if(0x0===_0x58a803['length'])return alert(_0x22759e(0x1e8)),!0x1;if(0x0===_0x414cb3[_0x22759e(0x337)])return alert(_0x22759e(0x326)),!0x1;if(_0x22759e(0x2b0)!==_0x2d852e&&0x0===_0x1cb967['length'])return alert('Veuillez\x20sélectionner\x20au\x20moins\x20une\x20garniture\x20ou\x20cocher\x20\x22sans\x20garniture\x22.'),!0x1;var _0x4a37dc=new FormData(this);_0x58a803[_0x22759e(0x315)](_0x30fc5d=>{const _0x407bfe=_0x22759e,_0x457280=_0x30fc5d[_0x407bfe(0x300)],_0x47bc6e=_0x30fc5d[_0x407bfe(0x219)](_0x407bfe(0x2d0)),_0x36e57b=_0x47bc6e?_0x47bc6e['querySelector'](_0x407bfe(0x288)):null,_0x23c0ee=_0x36e57b&&parseInt(_0x36e57b[_0x407bfe(0x300)],0xa)||0x1;_0x4a37dc[_0x407bfe(0x29a)](_0x407bfe(0x15e)+_0x457280+']',_0x23c0ee);});var _0x39757d=_0x47aee6();fetch(_0x22759e(0x17c),{'method':'POST','headers':{'X-CSRF-Token':_0x39757d},'body':_0x4a37dc})[_0x22759e(0x2be)](_0x5815fc=>{const _0x4c7e3a=_0x22759e;if(!_0x5815fc['ok'])throw new Error(_0x4c7e3a(0x26c));return _0x5815fc['text']();})[_0x22759e(0x2be)](_0x3bc297=>{const _0x55ec67=_0x22759e;$(_0x55ec67(0x18c))[_0x55ec67(0x33a)](_0x55ec67(0x1d0)),_0x2b3ace(),_0x5d92f3(),_0x43c433();})[_0x22759e(0x1a3)](_0x22b10d=>console['error'](_0x22759e(0x24b),_0x22b10d));});}),document['addEventListener'](_0x537fe3(0x2d9),function(){const _0x359f4b=_0x537fe3,_0xcf6c19=document['querySelectorAll'](_0x359f4b(0x16f)),_0x23bbad=_0x47aee6();fetch(_0x359f4b(0x333),{'method':'POST','headers':{'X-CSRF-Token':_0x23bbad}})[_0x359f4b(0x2be)](_0x2805ec=>{const _0x1e66ba=_0x359f4b;if(!_0x2805ec['ok'])throw 0x193===_0x2805ec[_0x1e66ba(0x2a5)]&&console[_0x1e66ba(0x2e2)](_0x1e66ba(0x2df)),new Error(_0x1e66ba(0x1d5));return _0x2805ec[_0x1e66ba(0x290)]();})['then'](_0x19a9e6=>{const _0x20e5a9=_0x359f4b;Object[_0x20e5a9(0x195)](_0x19a9e6)[_0x20e5a9(0x315)](_0x26ab4a=>{const _0x1d2acf=_0x20e5a9,_0x2be767=document[_0x1d2acf(0x239)](_0x26ab4a['id']);if(_0x2be767){_0x2be767[_0x1d2acf(0x1eb)]=!0x0;const _0x9a051c=_0x2be767['closest'](_0x1d2acf(0x167))[_0x1d2acf(0x268)](_0x1d2acf(0x24e));_0x9a051c['classList'][_0x1d2acf(0x200)](_0x1d2acf(0x189)),_0x9a051c['querySelector'](_0x1d2acf(0x325))[_0x1d2acf(0x300)]=_0x26ab4a['quantity'];const _0x5e5d65=document['getElementById'](_0x1d2acf(0x17f)+_0x26ab4a['id']);if(_0x5e5d65){if(_0x5e5d65[_0x1d2acf(0x1a5)]['remove']('d-none'),_0x26ab4a['free_sauces']&&Array['isArray'](_0x26ab4a[_0x1d2acf(0x260)]))_0x5e5d65[_0x1d2acf(0x293)]('select')['forEach']((_0x4fa08a,_0x1775c7)=>{const _0x42bb29=_0x1d2acf;_0x26ab4a['free_sauces'][_0x1775c7]&&_0x26ab4a[_0x42bb29(0x260)][_0x1775c7]['id']&&(_0x4fa08a[_0x42bb29(0x300)]=_0x26ab4a[_0x42bb29(0x260)][_0x1775c7]['id']);});else{if(_0x26ab4a[_0x1d2acf(0x324)]&&_0x26ab4a[_0x1d2acf(0x324)]['id']){const _0x595b07=_0x5e5d65['querySelector'](_0x1d2acf(0x1b7));_0x595b07&&(_0x595b07[_0x1d2acf(0x300)]=_0x26ab4a[_0x1d2acf(0x324)]['id']);}}}}});})[_0x359f4b(0x1a3)](_0x352291=>console[_0x359f4b(0x2b6)](_0x359f4b(0x24b),_0x352291)),(document['querySelectorAll'](_0x359f4b(0x1e7))[_0x359f4b(0x315)](_0x44778f=>{const _0x3fe312=_0x359f4b,_0x5e329c=_0x44778f['id'][_0x3fe312(0x24d)]('free_sauce_select_',''),_0x566517=document[_0x3fe312(0x239)](_0x5e329c);_0x566517&&_0x566517[_0x3fe312(0x1eb)]||_0x44778f[_0x3fe312(0x1a5)][_0x3fe312(0x165)](_0x3fe312(0x189));}),_0xcf6c19['forEach'](_0x32e72f=>{const _0x1ae0d3=_0x359f4b;_0x32e72f[_0x1ae0d3(0x329)](_0x1ae0d3(0x276),function(){const _0x12530e=_0x1ae0d3,_0x92e91f=this[_0x12530e(0x219)](_0x12530e(0x167))[_0x12530e(0x268)]('.extras-quantity-control'),_0x2c9aea=document[_0x12530e(0x239)](_0x12530e(0x17f)+this['id']);this[_0x12530e(0x1eb)]?(_0x92e91f['classList'][_0x12530e(0x200)](_0x12530e(0x189)),_0x2c9aea&&_0x2c9aea[_0x12530e(0x1a5)]['remove'](_0x12530e(0x189))):(_0x92e91f['classList']['add']('d-none'),_0x92e91f['querySelector'](_0x12530e(0x325))[_0x12530e(0x300)]=0x1,_0x2c9aea&&(_0x2c9aea[_0x12530e(0x1a5)]['add'](_0x12530e(0x189)),_0x2c9aea[_0x12530e(0x293)](_0x12530e(0x1b7))['forEach'](_0x4ccb4e=>{const _0x5d779f=_0x12530e;_0x4ccb4e[_0x5d779f(0x300)]='';})));const _0x27ded4=this['checked'],_0x432ccb=_0x27ded4?parseInt(_0x92e91f[_0x12530e(0x268)](_0x12530e(0x325))[_0x12530e(0x300)],0xa):0x0,_0x3fd826=this['id'],_0xfc099d=this[_0x12530e(0x201)](_0x12530e(0x300)),_0x5731c6=this[_0x12530e(0x219)](_0x12530e(0x167))['querySelector'](_0x12530e(0x1f2))[_0x12530e(0x1b8)],_0x37c922=parseFloat(_0x5731c6['replace'](_0x12530e(0x250),''))||0.5;['extra_frites',_0x12530e(0x192),_0x12530e(0x1ee),_0x12530e(0x1fb),'extra_onion_rings',_0x12530e(0x295),'extra_mozarella_sticks',_0x12530e(0x1e4),'extra_gaufrettes'][_0x12530e(0x1f0)](_0x3fd826)&&_0x2c9aea&&_0x27ded4?_0x1465a2(_0x3fd826):_0x20c88e(_0x3fd826,_0xfc099d,_0x37c922,_0x432ccb);});}),document[_0x359f4b(0x293)]('.free-sauces-container\x20select')[_0x359f4b(0x315)](_0x3e99db=>{_0x3e99db['addEventListener']('change',_0x348a6f);}),document['querySelectorAll'](_0x359f4b(0x22f))[_0x359f4b(0x315)](_0x3a4393=>{const _0x2ecb99=_0x359f4b;_0x3a4393[_0x2ecb99(0x329)](_0x2ecb99(0x274),function(){const _0x5bbb6d=_0x2ecb99,_0x248793=_0x3a4393[_0x5bbb6d(0x219)]('.extras-quantity-control')[_0x5bbb6d(0x268)](_0x5bbb6d(0x325));let _0x2effa6=parseInt(_0x248793[_0x5bbb6d(0x300)],0xa);const _0x10f89d=_0x3a4393[_0x5bbb6d(0x219)](_0x5bbb6d(0x167))[_0x5bbb6d(0x268)](_0x5bbb6d(0x1d7)),_0x156121=_0x10f89d['id'],_0x58cb9f=_0x10f89d[_0x5bbb6d(0x201)](_0x5bbb6d(0x300)),_0x387a66=_0x10f89d[_0x5bbb6d(0x219)](_0x5bbb6d(0x167))[_0x5bbb6d(0x268)]('.extras-info')[_0x5bbb6d(0x1b8)],_0x1a403a=parseFloat(_0x387a66[_0x5bbb6d(0x24d)](_0x5bbb6d(0x250),''))||0.5;_0x3a4393[_0x5bbb6d(0x1a5)][_0x5bbb6d(0x17d)]('increase')?_0x2effa6++:_0x2effa6>0x1&&_0x2effa6--,_0x248793[_0x5bbb6d(0x300)]=_0x2effa6,[_0x5bbb6d(0x20f),_0x5bbb6d(0x192),_0x5bbb6d(0x1ee),'extra_tenders',_0x5bbb6d(0x1cd),_0x5bbb6d(0x295),_0x5bbb6d(0x26f),_0x5bbb6d(0x1e4),_0x5bbb6d(0x2d2)][_0x5bbb6d(0x1f0)](_0x156121)?(!function(_0x5d9806,_0x3110b0){const _0x190020=_0x5bbb6d,_0x515c7a=_0x190020(0x19c)===window[_0x190020(0x186)][_0x190020(0x184)]||_0x190020(0x2f9)===window[_0x190020(0x186)][_0x190020(0x184)];_0x515c7a&&console['log'](_0x190020(0x2c7),_0x5d9806,_0x3110b0);const _0x2196cf=document[_0x190020(0x239)]('free_sauce_select_'+_0x5d9806);if(!_0x2196cf)return void(_0x515c7a&&console['log'](_0x190020(0x248),'free_sauce_select_'+_0x5d9806));const _0x51c227=_0x2196cf[_0x190020(0x293)](_0x190020(0x1b7)),_0x4fb19f=[];_0x51c227[_0x190020(0x315)](_0x32448c=>{const _0x2c964b=_0x190020;_0x32448c[_0x2c964b(0x300)]&&_0x4fb19f[_0x2c964b(0x2d1)](_0x32448c[_0x2c964b(0x300)]);}),_0x515c7a&&console[_0x190020(0x2e2)](_0x190020(0x1b5),_0x4fb19f),(_0x2196cf[_0x190020(0x27a)]='',_0x515c7a&&console[_0x190020(0x2e2)](_0x190020(0x2a0),_0x3110b0,'sauce\x20options'));for(let _0x5b4265=0x1;_0x5b4265<=_0x3110b0;_0x5b4265++){const _0x481701=document[_0x190020(0x16d)](_0x190020(0x26d));_0x481701[_0x190020(0x313)]=_0x190020(0x312);const _0xa30302=_0x4fb19f[_0x5b4265-0x1]||'';let _0x5aabd1=_0x190020(0x185);window[_0x190020(0x302)]&&Array[_0x190020(0x258)](window['availableSauces'])&&(_0x5aabd1='<option\x20value=\x22\x22\x20disabled\x20'+(_0xa30302?'':_0x190020(0x1d4))+_0x190020(0x1a7),window[_0x190020(0x302)][_0x190020(0x315)](_0x106aa2=>{const _0x4ef13c=_0x190020,_0x355b7b=_0xa30302===_0x106aa2['id']?_0x4ef13c(0x1d4):'';_0x5aabd1+=_0x4ef13c(0x18b)+_0x106aa2['id']+'\x22\x20'+_0x355b7b+'>'+_0x106aa2[_0x4ef13c(0x1f1)]+'</option>';})),_0x481701[_0x190020(0x27a)]=_0x190020(0x1bc)+_0x5b4265+_0x190020(0x286)+_0x5d9806+_0x190020(0x17e)+_0x5b4265+'\x22>\x0a\x20\x20\x20\x20\x20\x20\x20\x20'+_0x5aabd1+_0x190020(0x263),_0x2196cf[_0x190020(0x15b)](_0x481701);}_0x515c7a&&console[_0x190020(0x2e2)](_0x190020(0x210),_0x3110b0,_0x190020(0x2ed),_0x5d9806),!function(_0x40d02c){const _0x2dbbee=_0x190020,_0x2035d7=document[_0x2dbbee(0x293)](_0x2dbbee(0x25f)+_0x40d02c+_0x2dbbee(0x19b));_0x2035d7[_0x2dbbee(0x315)](_0x28c3ee=>{const _0x2ae1d1=_0x2dbbee;_0x28c3ee[_0x2ae1d1(0x175)](_0x2ae1d1(0x276),_0x348a6f),_0x28c3ee[_0x2ae1d1(0x329)](_0x2ae1d1(0x276),_0x348a6f);});}(_0x5d9806);}(_0x156121,_0x2effa6),_0x1465a2(_0x156121)):_0x20c88e(_0x156121,_0x58cb9f,_0x1a403a,_0x2effa6);});})),document['querySelectorAll'](_0x359f4b(0x157))[_0x359f4b(0x315)](_0x85f34=>{const _0x50375f=_0x359f4b;_0x85f34[_0x50375f(0x329)](_0x50375f(0x276),function(){const _0x38ca87=_0x50375f,_0x5305c1=document['getElementById'](_0x38ca87(0x2fa)+this['id']);this[_0x38ca87(0x1eb)]?_0x5305c1[_0x38ca87(0x1a5)][_0x38ca87(0x200)](_0x38ca87(0x189)):_0x5305c1[_0x38ca87(0x1a5)]['add'](_0x38ca87(0x189)),_0x5305c1[_0x38ca87(0x268)]('select')[_0x38ca87(0x329)](_0x38ca87(0x276),function(){const _0x773afc=_0x38ca87;_0x20c88e(this[_0x773afc(0x300)],this['options'][this[_0x773afc(0x183)]][_0x773afc(0x2ca)],0x0,0x1);});});});}),document['addEventListener']('DOMContentLoaded',function(){const _0x4b701c=_0x537fe3,_0x4fd6ed=document[_0x4b701c(0x293)](_0x4b701c(0x1f3));function _0x1314e1(_0x8e5a5f,_0x144cf6,_0x524d46,_0x2be603){const _0x5c4af4=_0x4b701c;var _0x3ae88d=_0x47aee6();const _0x268b0a={'id':_0x8e5a5f,'name':_0x144cf6,'price':_0x524d46,'quantity':_0x2be603};fetch('ajax/ubs.php',{'method':'POST','headers':{'X-CSRF-Token':_0x3ae88d},'body':JSON[_0x5c4af4(0x15d)](_0x268b0a)})[_0x5c4af4(0x2be)](_0x2bf3c2=>_0x2bf3c2[_0x5c4af4(0x290)]())['then'](_0x23a90d=>{_0x43c433();})[_0x5c4af4(0x1a3)](_0x4071c8=>console[_0x5c4af4(0x2b6)](_0x5c4af4(0x24b),_0x4071c8));}const _0x1f1d15=_0x47aee6();fetch(_0x4b701c(0x16a),{'method':_0x4b701c(0x1c8),'headers':{'X-CSRF-Token':_0x1f1d15}})[_0x4b701c(0x2be)](_0x33075f=>{const _0x1d89e5=_0x4b701c;if(!_0x33075f['ok'])throw 0x193===_0x33075f[_0x1d89e5(0x2a5)]&&console[_0x1d89e5(0x2e2)]('GSB\x20REFRESH'),new Error('GSB\x20Network\x20response\x20was\x20not\x20ok');return _0x33075f[_0x1d89e5(0x290)]();})[_0x4b701c(0x2be)](_0x4e565b=>{const _0x3ac3fa=_0x4b701c;Object[_0x3ac3fa(0x195)](_0x4e565b)['forEach'](_0x5919f4=>{const _0x2a9837=_0x3ac3fa,_0x2dd92a=document[_0x2a9837(0x239)](_0x5919f4['id']);if(_0x2dd92a){_0x2dd92a[_0x2a9837(0x1eb)]=!0x0;const _0x215f72=_0x2dd92a['closest'](_0x2a9837(0x167))['querySelector']('.boisson-quantity-control');_0x215f72[_0x2a9837(0x1a5)][_0x2a9837(0x200)](_0x2a9837(0x189)),_0x215f72[_0x2a9837(0x268)](_0x2a9837(0x325))['value']=_0x5919f4[_0x2a9837(0x261)];}});})['catch'](_0x44a586=>console[_0x4b701c(0x2b6)](_0x4b701c(0x24b),_0x44a586)),_0x4fd6ed['forEach'](_0x1e039e=>{const _0x38c34c=_0x4b701c;_0x1e039e[_0x38c34c(0x329)]('change',function(){const _0x1ca6ec=_0x38c34c,_0x42e4dc=this[_0x1ca6ec(0x219)](_0x1ca6ec(0x167))[_0x1ca6ec(0x268)]('.boisson-quantity-control');this['checked']?_0x42e4dc[_0x1ca6ec(0x1a5)][_0x1ca6ec(0x200)](_0x1ca6ec(0x189)):(_0x42e4dc[_0x1ca6ec(0x1a5)][_0x1ca6ec(0x165)](_0x1ca6ec(0x189)),_0x42e4dc[_0x1ca6ec(0x268)]('.quantity-input')[_0x1ca6ec(0x300)]=0x1);const _0x236c43=this[_0x1ca6ec(0x1eb)]?parseInt(_0x42e4dc[_0x1ca6ec(0x268)](_0x1ca6ec(0x325))[_0x1ca6ec(0x300)],0xa):0x0,_0x437885=this['id'],_0x217804=this[_0x1ca6ec(0x201)]('value'),_0x49ee6c=this['closest']('.form-check')['querySelector'](_0x1ca6ec(0x336))[_0x1ca6ec(0x1b8)];_0x1314e1(_0x437885,_0x217804,parseFloat(_0x49ee6c[_0x1ca6ec(0x24d)](_0x1ca6ec(0x250),''))||0.5,_0x236c43);});}),document[_0x4b701c(0x293)]('.boisson-quantity-control\x20.increase,\x20.boisson-quantity-control\x20.decrease')[_0x4b701c(0x315)](_0x302272=>{const _0x32a889=_0x4b701c;_0x302272[_0x32a889(0x329)](_0x32a889(0x274),function(){const _0x5240a7=_0x32a889,_0xde349e=this[_0x5240a7(0x219)]('.boisson-quantity-control')[_0x5240a7(0x268)](_0x5240a7(0x325));let _0x2e2cb8=parseInt(_0xde349e[_0x5240a7(0x300)],0xa);_0x2e2cb8+=this['classList'][_0x5240a7(0x17d)](_0x5240a7(0x1be))?0x1:_0x2e2cb8>0x1?-0x1:0x0,_0xde349e[_0x5240a7(0x300)]=_0x2e2cb8;const _0x208b15=this['closest'](_0x5240a7(0x2af))[_0x5240a7(0x201)](_0x5240a7(0x2d3)),_0x3b3a8b=document[_0x5240a7(0x239)](_0x208b15),_0x326289=_0x3b3a8b['getAttribute'](_0x5240a7(0x300)),_0x228110=_0x3b3a8b[_0x5240a7(0x219)](_0x5240a7(0x167))[_0x5240a7(0x268)](_0x5240a7(0x336))[_0x5240a7(0x1b8)];_0x1314e1(_0x208b15,_0x326289,parseFloat(_0x228110[_0x5240a7(0x24d)](_0x5240a7(0x250),''))||0.5,_0x2e2cb8);});});}),document[_0x537fe3(0x329)]('DOMContentLoaded',function(){const _0x5552fe=_0x537fe3,_0x485491=document['querySelectorAll'](_0x5552fe(0x22c));function _0xfe306c(_0x4a6d01,_0x5b4df2,_0x44a2f8,_0x1c3334){const _0x136de5=_0x5552fe;var _0x43f072=_0x47aee6();const _0xf28ac5={'id':_0x4a6d01,'name':_0x5b4df2,'price':_0x44a2f8,'quantity':_0x1c3334};fetch(_0x136de5(0x1e2),{'method':_0x136de5(0x1c8),'headers':{'X-CSRF-Token':_0x43f072},'body':JSON['stringify'](_0xf28ac5)})['then'](_0x5addaa=>_0x5addaa[_0x136de5(0x290)]())['then'](_0x3a02a0=>{_0x43c433();})[_0x136de5(0x1a3)](_0x130ccf=>console[_0x136de5(0x2b6)](_0x136de5(0x24b),_0x130ccf));}const _0x119505=_0x47aee6();fetch(_0x5552fe(0x2d8),{'method':_0x5552fe(0x1c8),'headers':{'X-CSRF-Token':_0x119505}})['then'](_0x3f0fc9=>{const _0xce7ae5=_0x5552fe;if(!_0x3f0fc9['ok'])throw 0x193===_0x3f0fc9[_0xce7ae5(0x2a5)]&&console[_0xce7ae5(0x2e2)]('GSD\x20REFRESH'),new Error(_0xce7ae5(0x342));return _0x3f0fc9[_0xce7ae5(0x290)]();})[_0x5552fe(0x2be)](_0x10058d=>{const _0x2ba598=_0x5552fe;Object['values'](_0x10058d)[_0x2ba598(0x315)](_0x39a3c6=>{const _0x26e083=_0x2ba598,_0x55c3cf=document[_0x26e083(0x239)](_0x39a3c6['id']);if(_0x55c3cf){_0x55c3cf[_0x26e083(0x1eb)]=!0x0;const _0x4668a6=_0x55c3cf[_0x26e083(0x219)]('.form-check')[_0x26e083(0x268)](_0x26e083(0x262));_0x4668a6['classList'][_0x26e083(0x200)]('d-none'),_0x4668a6[_0x26e083(0x268)]('.quantity-input')[_0x26e083(0x300)]=_0x39a3c6[_0x26e083(0x261)];}});})[_0x5552fe(0x1a3)](_0x362336=>console[_0x5552fe(0x2b6)]('Error:',_0x362336)),_0x485491[_0x5552fe(0x315)](_0x16f575=>{const _0x20c25b=_0x5552fe;_0x16f575[_0x20c25b(0x329)](_0x20c25b(0x276),function(){const _0x111403=_0x20c25b,_0x454838=this[_0x111403(0x219)](_0x111403(0x167))[_0x111403(0x268)](_0x111403(0x262));this[_0x111403(0x1eb)]?_0x454838['classList'][_0x111403(0x200)](_0x111403(0x189)):(_0x454838[_0x111403(0x1a5)][_0x111403(0x165)](_0x111403(0x189)),_0x454838[_0x111403(0x268)](_0x111403(0x325))['value']=0x1);const _0x1b071e=this[_0x111403(0x1eb)]?parseInt(_0x454838[_0x111403(0x268)]('.quantity-input')[_0x111403(0x300)],0xa):0x0,_0x437937=this['id'],_0x1d6814=this[_0x111403(0x201)]('value'),_0x25409d=this[_0x111403(0x219)]('.form-check')[_0x111403(0x268)](_0x111403(0x237))[_0x111403(0x1b8)];_0xfe306c(_0x437937,_0x1d6814,parseFloat(_0x25409d[_0x111403(0x24d)]('CHF\x20',''))||0.5,_0x1b071e);});}),document['querySelectorAll'](_0x5552fe(0x2d6))['forEach'](_0x2db0de=>{const _0x5ab6a9=_0x5552fe;_0x2db0de[_0x5ab6a9(0x329)](_0x5ab6a9(0x274),function(){const _0xf1cf27=_0x5ab6a9,_0x5e666d=this['closest'](_0xf1cf27(0x262))[_0xf1cf27(0x268)](_0xf1cf27(0x325));let _0x424dba=parseInt(_0x5e666d[_0xf1cf27(0x300)],0xa);_0x424dba+=this[_0xf1cf27(0x1a5)]['contains']('increase')?0x1:_0x424dba>0x1?-0x1:0x0,_0x5e666d['value']=_0x424dba;const _0x2dafbb=this['closest'](_0xf1cf27(0x262))[_0xf1cf27(0x201)](_0xf1cf27(0x2ef)),_0x2f943e=document[_0xf1cf27(0x239)](_0x2dafbb),_0x25ff2f=_0x2f943e[_0xf1cf27(0x201)](_0xf1cf27(0x300)),_0x262a57=_0x2f943e[_0xf1cf27(0x219)](_0xf1cf27(0x167))['querySelector'](_0xf1cf27(0x237))['textContent'];_0xfe306c(_0x2dafbb,_0x25ff2f,parseFloat(_0x262a57['replace']('CHF\x20',''))||0.5,_0x424dba);});});}),document[_0x537fe3(0x329)]('DOMContentLoaded',_0x52fe89),document['addEventListener'](_0x537fe3(0x2d9),_0x43c433),document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x24ffa2=_0x537fe3;document[_0x24ffa2(0x239)](_0x24ffa2(0x2ee))[_0x24ffa2(0x329)](_0x24ffa2(0x32c),function(_0x1ae7af){const _0x226e57=_0x24ffa2;var _0x486822=_0x47aee6();fetch(_0x226e57(0x2f0),{'method':'POST','headers':{'Content-Type':_0x226e57(0x1ba)},'body':_0x226e57(0x1c9)+encodeURIComponent(_0x486822)})[_0x226e57(0x2be)](_0x19dbb3=>{const _0x5ddb1c=_0x226e57;if(!_0x19dbb3['ok'])throw 0x193===_0x19dbb3['status']&&console['log'](_0x5ddb1c(0x335)),new Error(_0x5ddb1c(0x207));return _0x19dbb3[_0x5ddb1c(0x2ca)]();})[_0x226e57(0x2be)](_0x127da7=>{document['querySelector']('#orderModal\x20.order-summary')['innerHTML']=_0x127da7;})[_0x226e57(0x1a3)](_0x3be85e=>console[_0x226e57(0x2b6)]('Error\x20loading\x20the\x20order\x20summary:',_0x3be85e));});}),document[_0x537fe3(0x239)](_0x537fe3(0x19d))['addEventListener']('change',function(){const _0xa87091=_0x537fe3;_0x9e04ab(this[_0xa87091(0x300)],_0xa87091(0x2db));}),document[_0x537fe3(0x239)](_0x537fe3(0x33b))['addEventListener'](_0x537fe3(0x32c),function(){const _0x22729c=_0x537fe3;_0x9e04ab(document[_0x22729c(0x239)](_0x22729c(0x2f4))['value'],_0x22729c(0x271));}),document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x430bc2=_0x537fe3;document['querySelector'](_0x430bc2(0x1c6))[_0x430bc2(0x329)](_0x430bc2(0x274),function(){const _0x2f91fb=_0x430bc2;new bootstrap['Modal'](document[_0x2f91fb(0x239)]('confirmMinOrderModal'))[_0x2f91fb(0x1d0)](),setTimeout(function(){const _0x3d6adb=_0x2f91fb;new bootstrap[(_0x3d6adb(0x173))](document[_0x3d6adb(0x239)](_0x3d6adb(0x2ee)))['show']();},0x1f4);});}),document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x6b09eb=_0x537fe3,_0x69b6ef=document[_0x6b09eb(0x239)](_0x6b09eb(0x19d));function _0x26b64c(_0x663f96,_0x30d55f=!0x0){const _0x2977b9=_0x6b09eb;_0x663f96[_0x2977b9(0x315)](_0x8270e9=>{const _0x5e6f23=_0x2977b9;_0x8270e9[_0x5e6f23(0x1de)]=_0x30d55f,_0x30d55f&&(_0x8270e9[_0x5e6f23(0x1eb)]=!0x1);});}function _0x3b9b45(_0x226765){const _0x2ed723=_0x6b09eb;let _0x168391=[..._0x55487c][_0x2ed723(0x2fd)](_0x2746b1=>_0x2746b1[_0x2ed723(0x1eb)])[_0x2ed723(0x337)];_0x55487c[_0x2ed723(0x315)](_0x5b8c6f=>{_0x5b8c6f['addEventListener']('change',()=>{const _0x4ac8c6=a0_0x43d4;_0x168391=[..._0x55487c][_0x4ac8c6(0x2fd)](_0x2e0bc3=>_0x2e0bc3[_0x4ac8c6(0x1eb)])[_0x4ac8c6(0x337)],_0x168391>=_0x226765?_0x26b64c([..._0x55487c][_0x4ac8c6(0x2fd)](_0x5b7bc1=>!_0x5b7bc1['checked']),!0x0):_0x26b64c(_0x55487c,!0x1);});});}_0x55487c=document[_0x6b09eb(0x293)](_0x6b09eb(0x234)),_0x112180=document[_0x6b09eb(0x293)](_0x6b09eb(0x307)),_0x23890d=document['querySelectorAll'](_0x6b09eb(0x170)),_0x69b6ef[_0x6b09eb(0x329)]('change',()=>{const _0x20daf7=_0x6b09eb;[..._0x55487c,..._0x112180,..._0x23890d][_0x20daf7(0x315)](_0xb20a2e=>{const _0x421d77=_0x20daf7;_0xb20a2e[_0x421d77(0x1eb)]=!0x1;});const _0x196dff=_0x69b6ef[_0x20daf7(0x300)];switch(_0x26b64c(_0x55487c,!0x1),_0x26b64c(_0x112180,!0x1),_0x26b64c(_0x23890d,!0x1),_0x196dff){case'tacos_L':_0x3b9b45(0x1);break;case _0x20daf7(0x2b0):_0x3b9b45(0x2);break;case _0x20daf7(0x1ed):case _0x20daf7(0x212):_0x3b9b45(0x3);break;case'tacos_XXL':_0x3b9b45(0x4);break;case _0x20daf7(0x30e):_0x3b9b45(0x5);break;default:_0x26b64c(_0x55487c,!0x0),_0x26b64c(_0x112180,!0x0),_0x26b64c(_0x23890d,!0x0);}_0x112180[_0x20daf7(0x315)](_0x205ffb=>{const _0x88fb42=_0x20daf7;_0x205ffb['addEventListener'](_0x88fb42(0x276),()=>{const _0x25734e=_0x88fb42;[..._0x112180][_0x25734e(0x2fd)](_0x3c6da6=>_0x3c6da6[_0x25734e(0x1eb)])[_0x25734e(0x337)]>=0x3?_0x26b64c([..._0x112180][_0x25734e(0x2fd)](_0x5e9e1c=>!_0x5e9e1c[_0x25734e(0x1eb)]),!0x0):_0x26b64c(_0x112180,!0x1);});});}),(document[_0x6b09eb(0x293)](_0x6b09eb(0x323))['forEach'](_0x5be73c=>{const _0x194db2=_0x6b09eb;_0x5be73c[_0x194db2(0x329)](_0x194db2(0x274),function(_0x42e613){const _0x2a7ea1=_0x194db2;_0x42e613[_0x2a7ea1(0x2f1)](),!async function(_0x343318){const _0x13ff77=_0x2a7ea1;new bootstrap[(_0x13ff77(0x173))](document[_0x13ff77(0x239)](_0x13ff77(0x1db)),{'keyboard':!0x1})[_0x13ff77(0x14c)](),document[_0x13ff77(0x239)](_0x13ff77(0x19d))[_0x13ff77(0x300)]=_0x343318,_0x69b6ef[_0x13ff77(0x1a9)](new Event('change',{'bubbles':!0x0,'cancelable':!0x0})),await _0x2b43b1(),_0x35e7bf();}(this['getAttribute'](_0x2a7ea1(0x153)));});}),_0x26b64c(_0x55487c),_0x26b64c(_0x112180),_0x26b64c(_0x23890d),$(_0x6b09eb(0x23f))['on'](_0x6b09eb(0x311),function(){const _0x31b0cd=_0x6b09eb;_0xc3c9b1(),_0x69b6ef[_0x31b0cd(0x300)]='null',_0x26b64c(_0x55487c,!0x0),_0x26b64c(_0x112180,!0x0),_0x26b64c(_0x23890d,!0x0);}));}),$('#tacosForm')[_0x537fe3(0x314)](function(_0x5d76a5){const _0x3fbf27=_0x537fe3;_0x5d76a5[_0x3fbf27(0x2f1)]();const _0x2b8cf5=document[_0x3fbf27(0x239)](_0x3fbf27(0x19d))[_0x3fbf27(0x300)],_0x2df9c0=document[_0x3fbf27(0x293)](_0x3fbf27(0x1ca)),_0x436197=document[_0x3fbf27(0x293)](_0x3fbf27(0x1c4)),_0x2dcc7d=document[_0x3fbf27(0x293)](_0x3fbf27(0x2d5));document[_0x3fbf27(0x268)](_0x3fbf27(0x2c2)),document[_0x3fbf27(0x268)]('input[name=\x22sauce[]\x22][value=\x22sans\x22]:checked'),document[_0x3fbf27(0x268)](_0x3fbf27(0x16c));if(0x0===_0x2df9c0[_0x3fbf27(0x337)])return alert(_0x3fbf27(0x1e8)),!0x1;if(0x0===_0x436197[_0x3fbf27(0x337)])return alert(_0x3fbf27(0x326)),!0x1;if(_0x3fbf27(0x2b0)!==_0x2b8cf5&&0x0===_0x2dcc7d[_0x3fbf27(0x337)])return alert('Veuillez\x20sélectionner\x20au\x20moins\x20une\x20garniture\x20ou\x20cocher\x20\x22sans\x20garniture\x22.'),!0x1;var _0x22bd28=_0x47aee6();const _0x83e35c={};_0x2df9c0[_0x3fbf27(0x315)](_0x34e18d=>{const _0x3e5dc4=_0x3fbf27,_0x281d57=_0x34e18d['value'],_0x16ef78=_0x34e18d['closest'](_0x3e5dc4(0x2d0)),_0x402287=_0x16ef78?_0x16ef78[_0x3e5dc4(0x268)](_0x3e5dc4(0x288)):null,_0x1abbe5=_0x402287&&parseInt(_0x402287[_0x3e5dc4(0x300)],0xa)||0x1;_0x83e35c[_0x281d57]=_0x1abbe5;});let _0xe34811=$(this)['serialize']();Object[_0x3fbf27(0x26e)](_0x83e35c)[_0x3fbf27(0x315)](_0x2cefc4=>{const _0x37da8a=_0x3fbf27;_0xe34811+=_0x37da8a(0x154)+_0x2cefc4+']='+_0x83e35c[_0x2cefc4];}),$[_0x3fbf27(0x1d3)]({'type':'POST','url':_0x3fbf27(0x2f6),'headers':{'X-CSRF-Token':_0x22bd28},'data':_0xe34811,'success':function(_0x3a0047){const _0x1c3af9=_0x3fbf27;$(_0x1c3af9(0x270))[_0x1c3af9(0x29a)](_0x3a0047),$(_0x1c3af9(0x2e3))['empty'](),_0x2b3ace(),_0x5d92f3(),_0x43c433();},'error':function(){alert('Error\x20on\x20submit.\x20Please\x20try\x20again.');}}),$(_0x3fbf27(0x23f))[_0x3fbf27(0x33a)]('hide'),_0xc3c9b1();}),$(document)['on'](_0x537fe3(0x274),_0x537fe3(0x218),function(_0x314073){const _0x518686=_0x537fe3;_0x314073[_0x518686(0x2f1)]();var _0x1ea80e=$(this)['attr']('data-index');if(confirm(_0x518686(0x339))){var _0x49e47e=_0x47aee6();$[_0x518686(0x1d3)]({'url':_0x518686(0x156),'headers':{'X-CSRF-Token':_0x49e47e},'type':_0x518686(0x1c8),'data':{'index':_0x1ea80e},'success':function(_0x20d692){const _0x3a84d2=_0x518686;$('#tacos-'+_0x1ea80e)[_0x3a84d2(0x200)](),_0x5d92f3(),_0x43c433();},'error':function(){alert('Error\x20on\x20delete.\x20Please\x20try\x20again.');}});}}),$(document)[_0x537fe3(0x21d)](function(){_0x2b3ace();}),document[_0x537fe3(0x239)](_0x537fe3(0x308))['addEventListener'](_0x537fe3(0x314),function(_0x3dad45){const _0x21cb5a=_0x537fe3;_0x3dad45[_0x21cb5a(0x2f1)]();const _0x4f1851=document[_0x21cb5a(0x239)]('finalizeButton'),_0x40ee4f=_0x4f1851?_0x4f1851['innerHTML']:'Finaliser\x20la\x20commande';if(document[_0x21cb5a(0x239)](_0x21cb5a(0x1fe))['value']!==document[_0x21cb5a(0x239)](_0x21cb5a(0x287))['value'])return void alert(_0x21cb5a(0x1bf));_0x4f1851&&(_0x4f1851['disabled']=!0x0,_0x4f1851[_0x21cb5a(0x27a)]=_0x21cb5a(0x1f9),_0x4f1851[_0x21cb5a(0x1a5)][_0x21cb5a(0x165)](_0x21cb5a(0x1de)));const _0x32f5c8=Date[_0x21cb5a(0x14e)]()+'_'+Math['random']()['toString'](0x24)['substr'](0x2,0x9),_0x312021=_0x47aee6();var _0x5cc408=new FormData(this);_0x5cc408[_0x21cb5a(0x29a)](_0x21cb5a(0x34c),_0x32f5c8),fetch(_0x21cb5a(0x14d),{'method':_0x21cb5a(0x1c8),'headers':{'X-CSRF-Token':_0x312021},'body':_0x5cc408})[_0x21cb5a(0x2be)](_0x5bfbb0=>{const _0x2d1167=_0x21cb5a;if(!_0x5bfbb0['ok']){if(0x199===_0x5bfbb0[_0x2d1167(0x2a5)])return _0x5bfbb0['json']()[_0x2d1167(0x2be)](_0x5a1e72=>{throw new Error('DUPLICATE_ORDER');});if(0x193===_0x5bfbb0[_0x2d1167(0x2a5)])return _0x5bfbb0[_0x2d1167(0x2ca)]()['then'](_0x33cc81=>{const _0x52f623=_0x2d1167;if(_0x33cc81[_0x52f623(0x1f0)]('1\x20Order\x20per\x20minute')||_0x33cc81['includes'](_0x52f623(0x20a)))throw new Error(_0x52f623(0x345));throw new Error(_0x52f623(0x304));});throw new Error('RocknRoll\x20Network\x20response\x20was\x20not\x20ok');}return _0x5bfbb0[_0x2d1167(0x290)]();})['then'](_0x28660b=>{const _0x4f30fd=_0x21cb5a;if(!_0x28660b)throw console[_0x4f30fd(0x2b6)](_0x4f30fd(0x29e),_0x28660b),new Error(_0x4f30fd(0x24a));{_0x4f1851&&(_0x4f1851[_0x4f30fd(0x1a5)][_0x4f30fd(0x200)](_0x4f30fd(0x1af)),_0x4f1851[_0x4f30fd(0x1a5)][_0x4f30fd(0x165)](_0x4f30fd(0x32e)),_0x4f1851['innerHTML']=_0x4f30fd(0x180)),localStorage[_0x4f30fd(0x1fc)](_0x4f30fd(0x2cd)),document[_0x4f30fd(0x293)](_0x4f30fd(0x209))[_0x4f30fd(0x315)](_0x35f863=>{const _0x570640=_0x4f30fd;new bootstrap[(_0x570640(0x223))](_0x35f863,{'toggle':!0x1})[_0x570640(0x1d0)]();});var _0x144cb2=localStorage['getItem']('order_stories');(_0x144cb2=_0x144cb2?JSON[_0x4f30fd(0x32b)](_0x144cb2):[])['push'](_0x28660b),localStorage[_0x4f30fd(0x281)]('order_stories',JSON[_0x4f30fd(0x15d)](_0x144cb2));let _0x349c4d='';_0x4f30fd(0x162)===new URLSearchParams(window[_0x4f30fd(0x186)][_0x4f30fd(0x348)])[_0x4f30fd(0x2b5)](_0x4f30fd(0x171))?_0x349c4d='<div\x20class=\x22d-flex\x20justify-content-center\x20align-items-center\x22\x20style=\x22height:\x20100px;\x22><i\x20class=\x27fa\x20fa-check-circle\x27\x20style=\x27color:\x20green;\x20font-size:\x20100px;\x27></i></div><br\x20/>Votre\x20commande\x20a\x20été\x20reçue\x20et\x20sera\x20préparée.<br>Restez\x20joignable\x20s\x27il\x20vous\x20plaît.<br>Celui-ci\x20sera\x20mis\x20à\x20jour\x20lorsque\x20votre\x20commande\x20sera\x20en\x20route.':_0x4f30fd(0x259)===new URLSearchParams(window[_0x4f30fd(0x186)][_0x4f30fd(0x348)])[_0x4f30fd(0x2b5)](_0x4f30fd(0x171))&&(_0x349c4d=_0x4f30fd(0x1b3)),$(_0x4f30fd(0x233))['on'](_0x4f30fd(0x311),function(){const _0xfa9809=_0x4f30fd;$('#successModalBody')[_0xfa9809(0x2c6)](_0x349c4d),$(_0xfa9809(0x1a2))['modal'](_0xfa9809(0x14c));})[_0x4f30fd(0x33a)](_0x4f30fd(0x1d0)),$('#successModal')['on'](_0x4f30fd(0x311),function(){const _0x10cafd=_0x4f30fd;window[_0x10cafd(0x186)]['reload']();}),gtag(_0x4f30fd(0x2a9),'purchase',{'transaction_id':_0x28660b[_0x4f30fd(0x231)],'affiliation':_0x4f30fd(0x306),'value':_0x28660b['OrderData']['price'],'currency':_0x4f30fd(0x1ce)});}})[_0x21cb5a(0x1a3)](_0x46a311=>{const _0x239f7e=_0x21cb5a;_0x239f7e(0x1e9)!=typeof isDevMode&&isDevMode&&(console[_0x239f7e(0x2b6)](_0x239f7e(0x29f),_0x46a311[_0x239f7e(0x1f1)]),console[_0x239f7e(0x2b6)]('Error\x20message:',_0x46a311[_0x239f7e(0x2f5)]),console[_0x239f7e(0x2b6)]('Error\x20stack:',_0x46a311[_0x239f7e(0x19e)])),_0x4f1851&&(_0x239f7e(0x1a0)===_0x46a311[_0x239f7e(0x2f5)]?(_0x4f1851[_0x239f7e(0x1a5)]['remove'](_0x239f7e(0x1af)),_0x4f1851[_0x239f7e(0x1a5)][_0x239f7e(0x165)]('btn-info'),_0x4f1851[_0x239f7e(0x27a)]=_0x239f7e(0x1a1),setTimeout(()=>{const _0x126e95=_0x239f7e;_0x4f1851['disabled']=!0x1,_0x4f1851['classList']['remove']('btn-info',_0x126e95(0x1de)),_0x4f1851['classList'][_0x126e95(0x165)](_0x126e95(0x1af)),_0x4f1851[_0x126e95(0x27a)]=_0x40ee4f;},0xbb8)):_0x239f7e(0x345)===_0x46a311[_0x239f7e(0x2f5)]?(_0x4f1851[_0x239f7e(0x1a5)][_0x239f7e(0x200)]('btn-danger'),_0x4f1851[_0x239f7e(0x1a5)][_0x239f7e(0x165)](_0x239f7e(0x181)),_0x4f1851[_0x239f7e(0x27a)]='<i\x20class=\x22fas\x20fa-exclamation-triangle\x20me-2\x22></i>Veuillez\x20patienter\x201\x20minute',setTimeout(()=>{const _0x5ad18a=_0x239f7e;_0x4f1851[_0x5ad18a(0x1de)]=!0x1,_0x4f1851[_0x5ad18a(0x1a5)]['remove']('btn-warning',_0x5ad18a(0x1de)),_0x4f1851[_0x5ad18a(0x1a5)]['add'](_0x5ad18a(0x1af)),_0x4f1851[_0x5ad18a(0x27a)]=_0x40ee4f;},0x1388)):_0x46a311['message'][_0x239f7e(0x1f0)](_0x239f7e(0x1f5))?(_0x4f1851[_0x239f7e(0x1a5)][_0x239f7e(0x165)](_0x239f7e(0x1af)),_0x4f1851['innerHTML']=_0x239f7e(0x2fe),setTimeout(()=>{const _0xe1845e=_0x239f7e;_0x4f1851[_0xe1845e(0x1de)]=!0x1,_0x4f1851[_0xe1845e(0x1a5)][_0xe1845e(0x200)](_0xe1845e(0x1de)),_0x4f1851['innerHTML']=_0x40ee4f;},0xbb8)):(_0x4f1851[_0x239f7e(0x1a5)][_0x239f7e(0x165)]('btn-danger'),_0x4f1851['innerHTML']=_0x239f7e(0x292),setTimeout(()=>{const _0x319451=_0x239f7e;_0x4f1851['disabled']=!0x1,_0x4f1851[_0x319451(0x1a5)][_0x319451(0x200)]('disabled'),_0x4f1851[_0x319451(0x27a)]=_0x40ee4f;},0xbb8))),_0x239f7e(0x345)===_0x46a311[_0x239f7e(0x2f5)]?alert(_0x239f7e(0x1f7)):_0x239f7e(0x304)===_0x46a311[_0x239f7e(0x2f5)]?alert(_0x239f7e(0x267)):_0x46a311[_0x239f7e(0x2f5)][_0x239f7e(0x1f0)](_0x239f7e(0x1f5))?alert(_0x239f7e(0x2bb)):alert(_0x239f7e(0x2c9));});}),document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x1cfd39=_0x537fe3,_0x2080bf=document[_0x1cfd39(0x239)](_0x1cfd39(0x340)),_0x12fe61=document[_0x1cfd39(0x239)](_0x1cfd39(0x1f8)),_0x63a503=navigator['userAgent'][_0x1cfd39(0x256)]();function _0x5435af(_0x5b4b93,_0x24442b){_0x2080bf['textContent']=_0x5b4b93,_0x12fe61['src']=_0x24442b;}/iphone|ipad/[_0x1cfd39(0x15c)](_0x63a503)?_0x5435af(_0x1cfd39(0x283),'./images/ios-share.png'):/android/['test'](_0x63a503)&&_0x5435af(_0x1cfd39(0x2dd),_0x1cfd39(0x349));});let _0x11635a=0x1;function _0x348a6f(_0x4587bf){const _0x20f433=_0x537fe3,_0x535624=_0x4587bf[_0x20f433(0x2dc)][_0x20f433(0x219)](_0x20f433(0x1e7));_0x535624&&_0x1465a2(_0x535624['id'][_0x20f433(0x24d)](_0x20f433(0x17f),''));}function _0x1465a2(_0x49881d){const _0x556a83=_0x537fe3,_0x6a5a15=document[_0x556a83(0x239)](_0x49881d),_0x406233=_0x6a5a15[_0x556a83(0x219)]('.form-check')[_0x556a83(0x268)](_0x556a83(0x325)),_0x51a4cd=parseInt(_0x406233[_0x556a83(0x300)],0xa),_0x2b41ff=_0x6a5a15[_0x556a83(0x201)]('value'),_0x378ceb=_0x6a5a15[_0x556a83(0x219)]('.form-check')[_0x556a83(0x268)](_0x556a83(0x1f2))[_0x556a83(0x1b8)],_0x3f0e8f=parseFloat(_0x378ceb[_0x556a83(0x24d)](_0x556a83(0x250),''))||0.5,_0x5a154b=document[_0x556a83(0x293)](_0x556a83(0x25f)+_0x49881d+_0x556a83(0x19b)),_0x3a812d=[];_0x5a154b[_0x556a83(0x315)](_0x5559ea=>{const _0x511ad1=_0x556a83;if(_0x5559ea[_0x511ad1(0x300)]){const _0x5bc344=_0x5559ea[_0x511ad1(0x1ef)][_0x5559ea[_0x511ad1(0x183)]]['text'];_0x3a812d[_0x511ad1(0x2d1)]({'id':_0x5559ea[_0x511ad1(0x300)],'name':_0x5bc344,'price':0x0});}}),_0x20c88e(_0x49881d,_0x2b41ff,_0x3f0e8f,_0x51a4cd,null,null,_0x3a812d);}document[_0x537fe3(0x329)](_0x537fe3(0x2d9),function(){const _0x125274=_0x537fe3,_0x460fab=document[_0x125274(0x239)](_0x125274(0x19d)),_0x44c59b=document['querySelectorAll'](_0x125274(0x234)),_0x147a8f=document[_0x125274(0x293)](_0x125274(0x307)),_0x4416e6=document['querySelectorAll'](_0x125274(0x170));function _0x411946(){const _0x553be2=_0x125274,_0x32cb0a=[..._0x44c59b][_0x553be2(0x2fd)](_0x23aac3=>_0x23aac3[_0x553be2(0x1eb)]);let _0x39dff6=0x0;0x1===_0x11635a?_0x39dff6=_0x32cb0a[_0x553be2(0x337)]:_0x32cb0a[_0x553be2(0x315)](_0x5232bf=>{const _0xde5baa=_0x553be2,_0x492872=_0x5232bf[_0xde5baa(0x219)](_0xde5baa(0x2d0));if(_0x492872){const _0x5ecbbb=_0x492872['querySelector'](_0xde5baa(0x288)),_0x2684e2=parseInt(_0x5ecbbb?.[_0xde5baa(0x300)]||0x1);_0x39dff6+=_0x2684e2;}}),_0x44c59b[_0x553be2(0x315)](_0x47b119=>{const _0x28daa3=_0x553be2;_0x47b119[_0x28daa3(0x1eb)]||(_0x47b119[_0x28daa3(0x1de)]=_0x39dff6>=_0x11635a);}),_0x32cb0a[_0x553be2(0x315)](_0x134da7=>{const _0x4c9647=_0x553be2,_0x18bce7=_0x134da7[_0x4c9647(0x219)](_0x4c9647(0x2d0));if(_0x18bce7){const _0x2ebe79=_0x18bce7['querySelector'](_0x4c9647(0x288));if(_0x2ebe79){const _0x21b4b0=parseInt(_0x2ebe79['value']),_0x355d63=_0x11635a-_0x39dff6+_0x21b4b0;_0x2ebe79[_0x4c9647(0x205)]=Math['min'](_0x355d63,0x5),_0x21b4b0>_0x2ebe79[_0x4c9647(0x205)]&&(_0x2ebe79[_0x4c9647(0x300)]=_0x2ebe79['max']);}}});}_0x44c59b[_0x125274(0x315)](_0x13e067=>{const _0x209255=_0x125274;_0x13e067[_0x209255(0x329)](_0x209255(0x276),function(){const _0x46a6f8=_0x209255,_0x566657=this['closest']('.meat-selection-row');if(_0x566657){const _0x4e4244=_0x566657[_0x46a6f8(0x268)](_0x46a6f8(0x2c1));if(_0x4e4244){if(this[_0x46a6f8(0x1eb)]&&_0x11635a>0x1)_0x4e4244[_0x46a6f8(0x1a5)][_0x46a6f8(0x200)]('d-none'),_0x411946();else{_0x4e4244[_0x46a6f8(0x1a5)][_0x46a6f8(0x165)](_0x46a6f8(0x189));const _0x802dc2=_0x4e4244[_0x46a6f8(0x268)](_0x46a6f8(0x288));_0x802dc2&&(_0x802dc2[_0x46a6f8(0x300)]=0x1);}}}_0x411946();});}),document[_0x125274(0x293)](_0x125274(0x19f))['forEach'](_0x2f595b=>{const _0x35f6ff=_0x125274;_0x2f595b[_0x35f6ff(0x329)]('click',function(){const _0x2fcac7=_0x35f6ff,_0x1d40b5=this[_0x2fcac7(0x1b6)][_0x2fcac7(0x268)](_0x2fcac7(0x288));if(_0x1d40b5){const _0x309dc3=parseInt(_0x1d40b5[_0x2fcac7(0x300)])||0x1;_0x309dc3<(parseInt(_0x1d40b5[_0x2fcac7(0x205)])||_0x11635a)&&(_0x1d40b5[_0x2fcac7(0x300)]=_0x309dc3+0x1,_0x411946());}});}),document[_0x125274(0x293)](_0x125274(0x15a))[_0x125274(0x315)](_0x154400=>{const _0xbc69e7=_0x125274;_0x154400[_0xbc69e7(0x329)](_0xbc69e7(0x274),function(){const _0x1f152d=_0xbc69e7,_0x894774=this[_0x1f152d(0x1b6)][_0x1f152d(0x268)](_0x1f152d(0x288));if(_0x894774){const _0xd88152=parseInt(_0x894774['value'])||0x1;_0xd88152>0x1&&(_0x894774[_0x1f152d(0x300)]=_0xd88152-0x1,_0x411946());}});}),_0x147a8f['forEach'](_0x2db7e5=>{const _0x3071df=_0x125274;_0x2db7e5[_0x3071df(0x329)](_0x3071df(0x276),function(){const _0x32b547=_0x3071df;[..._0x147a8f]['filter'](_0x427e0c=>_0x427e0c['checked'])[_0x32b547(0x337)]>=0x3?[..._0x147a8f][_0x32b547(0x2fd)](_0x3dc028=>!_0x3dc028[_0x32b547(0x1eb)])[_0x32b547(0x315)](_0x2b6583=>_0x2b6583[_0x32b547(0x1de)]=!0x0):_0x147a8f[_0x32b547(0x315)](_0x356c36=>{const _0x12439a=_0x32b547;_0x356c36[_0x12439a(0x1eb)]||(_0x356c36[_0x12439a(0x1de)]=!0x1);});});}),_0x460fab&&(_0x460fab[_0x125274(0x329)]('change',function(){const _0x5ccce1=_0x125274,_0x3d76d2=this[_0x5ccce1(0x300)];switch([..._0x44c59b,..._0x147a8f,..._0x4416e6][_0x5ccce1(0x315)](_0x1f1dd1=>{const _0x10e7f3=_0x5ccce1;_0x1f1dd1[_0x10e7f3(0x1eb)]=!0x1,_0x1f1dd1[_0x10e7f3(0x1de)]=!0x1;}),document[_0x5ccce1(0x293)](_0x5ccce1(0x2c1))[_0x5ccce1(0x315)](_0x18e315=>{const _0x5ea374=_0x5ccce1;_0x18e315[_0x5ea374(0x1a5)]['add'](_0x5ea374(0x189));const _0x473994=_0x18e315[_0x5ea374(0x268)]('.meat-quantity-input');_0x473994&&(_0x473994[_0x5ea374(0x300)]=0x1);}),_0x3d76d2){case _0x5ccce1(0x2ba):_0x11635a=0x1;break;case _0x5ccce1(0x2b0):_0x11635a=0x2;break;case _0x5ccce1(0x1ed):case'tacos_XL':_0x11635a=0x3;break;case'tacos_XXL':_0x11635a=0x4;break;case _0x5ccce1(0x30e):_0x11635a=0x5;break;default:return _0x11635a=0x0,void[..._0x44c59b,..._0x147a8f,..._0x4416e6][_0x5ccce1(0x315)](_0x4ddade=>_0x4ddade[_0x5ccce1(0x1de)]=!0x0);}[..._0x44c59b,..._0x147a8f,..._0x4416e6][_0x5ccce1(0x315)](_0x18014a=>_0x18014a[_0x5ccce1(0x1de)]=!0x1);}),[..._0x44c59b,..._0x147a8f,..._0x4416e6][_0x125274(0x315)](_0x3317b1=>_0x3317b1['disabled']=!0x0)),$(_0x125274(0x23f))['on'](_0x125274(0x311),function(){const _0x472222=_0x125274;_0x460fab&&(_0x460fab[_0x472222(0x300)]=_0x472222(0x1bb),[..._0x44c59b,..._0x147a8f,..._0x4416e6][_0x472222(0x315)](_0x316bb9=>{const _0x17de98=_0x472222;_0x316bb9[_0x17de98(0x1eb)]=!0x1,_0x316bb9[_0x17de98(0x1de)]=!0x0;}),document['querySelectorAll'](_0x472222(0x2c1))['forEach'](_0x2bf7c7=>{const _0x283cf1=_0x472222;_0x2bf7c7[_0x283cf1(0x1a5)][_0x283cf1(0x165)](_0x283cf1(0x189));const _0xd33737=_0x2bf7c7['querySelector']('.meat-quantity-input');_0xd33737&&(_0xd33737[_0x283cf1(0x300)]=0x1);}),_0x11635a=0x0);});}),document['addEventListener'](_0x537fe3(0x2d9),function(){const _0x119355=_0x537fe3;document[_0x119355(0x293)](_0x119355(0x217))['forEach'](_0x41f40e=>{const _0x245010=_0x119355;_0x41f40e[_0x245010(0x329)](_0x245010(0x276),function(){const _0x427870=_0x245010,_0x2d7bf8=this[_0x427870(0x219)](_0x427870(0x2d0));if(_0x2d7bf8){const _0x4ba95a=_0x2d7bf8[_0x427870(0x268)]('.meat-quantity-control');if(_0x4ba95a){let _0x3e63b2=0x1;switch(document[_0x427870(0x239)](_0x427870(0x18f))[_0x427870(0x300)]){case _0x427870(0x2ba):_0x3e63b2=0x1;break;case _0x427870(0x1ed):case _0x427870(0x212):_0x3e63b2=0x3;break;case _0x427870(0x317):_0x3e63b2=0x4;break;case _0x427870(0x30e):_0x3e63b2=0x5;}const _0x36a9fc=_0x4ba95a[_0x427870(0x268)]('.meat-quantity-input');this[_0x427870(0x1eb)]&&_0x3e63b2>0x1?(_0x4ba95a[_0x427870(0x1a5)][_0x427870(0x200)](_0x427870(0x189)),_0x36a9fc&&(_0x36a9fc[_0x427870(0x1de)]=!0x1)):(_0x4ba95a[_0x427870(0x1a5)][_0x427870(0x165)](_0x427870(0x189)),_0x36a9fc&&(_0x36a9fc[_0x427870(0x300)]=0x1,_0x36a9fc[_0x427870(0x1de)]=!0x0));}}});}),document[_0x119355(0x293)](_0x119355(0x2b1))['forEach'](_0x4ed2c5=>{const _0x295fc8=_0x119355;_0x4ed2c5[_0x295fc8(0x329)](_0x295fc8(0x274),function(){const _0x4293a6=_0x295fc8,_0x38db9b=this[_0x4293a6(0x1b6)]['querySelector'](_0x4293a6(0x288));if(_0x38db9b){const _0x117e57=parseInt(_0x38db9b[_0x4293a6(0x300)])||0x1;_0x117e57<(parseInt(_0x38db9b[_0x4293a6(0x205)])||0x5)&&(_0x38db9b[_0x4293a6(0x300)]=_0x117e57+0x1);}});}),document[_0x119355(0x293)](_0x119355(0x2e0))[_0x119355(0x315)](_0x41a64c=>{const _0x89d5c8=_0x119355;_0x41a64c[_0x89d5c8(0x329)](_0x89d5c8(0x274),function(){const _0x25f389=_0x89d5c8,_0x415698=this['parentElement']['querySelector'](_0x25f389(0x288));if(_0x415698){const _0x44945f=parseInt(_0x415698[_0x25f389(0x300)])||0x1;_0x44945f>0x1&&(_0x415698[_0x25f389(0x300)]=_0x44945f-0x1);}});});}),document[_0x537fe3(0x329)]('DOMContentLoaded',function(){const _0x79295d=_0x537fe3;try{if(!window[_0x79295d(0x186)][_0x79295d(0x348)]['includes'](_0x79295d(0x285)))return;const _0x3e72d8=document['querySelector']('select[name=\x22requestedFor\x22]'),_0x44e783=document[_0x79295d(0x239)](_0x79295d(0x1d1)),_0x2ea230=document[_0x79295d(0x239)](_0x79295d(0x34b));if(_0x3e72d8&&_0x44e783&&_0x2ea230){let _0x4340e1=!0x1;_0x3e72d8[_0x79295d(0x329)](_0x79295d(0x276),function(){const _0x714556=this['value'];_0x714556&&''!==_0x714556?_0x3b0922(_0x714556):_0x44e783['classList']['add']('d-none');}),_0x3e72d8[_0x79295d(0x300)]&&''!==_0x3e72d8['value']&&_0x3b0922(_0x3e72d8[_0x79295d(0x300)]);const _0x5d2821=document[_0x79295d(0x268)](_0x79295d(0x233));_0x5d2821&&_0x5d2821[_0x79295d(0x329)]('shown.bs.modal',function(){_0x4340e1||(!(function(){const _0x32934b=a0_0x43d4,_0x5c0093=document[_0x32934b(0x268)](_0x32934b(0x32f));if(!_0x5c0093)return;const _0x159d18=document[_0x32934b(0x268)](_0x32934b(0x1fa))?.[_0x32934b(0x300)]||'';fetch('ajax/check_delivery_demand.php',{'method':_0x32934b(0x1c8),'headers':{'Content-Type':_0x32934b(0x291),'X-CSRF-TOKEN':_0x159d18},'body':JSON[_0x32934b(0x15d)]({'check_all':!0x0})})[_0x32934b(0x2be)](_0x1dd51b=>_0x1dd51b[_0x32934b(0x290)]())[_0x32934b(0x2be)](_0x1131b1=>{const _0x101378=_0x32934b;'success'===_0x1131b1['status']&&_0x1131b1[_0x101378(0x30f)]&&_0x5c0093['querySelectorAll'](_0x101378(0x33d))['forEach'](_0x3f4eee=>{const _0x4cc550=_0x101378,_0x511a78=_0x3f4eee[_0x4cc550(0x300)],_0xe8231d=[_0x511a78,_0x511a78+_0x4cc550(0x1c1)];let _0x75ed77=!0x1;for(const _0x70bc3d of _0xe8231d)if(_0x1131b1['time_slots'][_0x70bc3d]&&_0x1131b1[_0x4cc550(0x30f)][_0x70bc3d][_0x4cc550(0x347)]){_0x75ed77=!0x0;break;}if(_0x75ed77&&!_0x3f4eee[_0x4cc550(0x1b8)][_0x4cc550(0x1f0)](_0x4cc550(0x232))){const _0x138749=_0x3f4eee['textContent'];_0x3f4eee['textContent']=_0x138749+_0x4cc550(0x191),_0x3f4eee[_0x4cc550(0x2cb)]['color']='#dc3545',_0x3f4eee[_0x4cc550(0x1a5)][_0x4cc550(0x165)]('high-demand');}});})[_0x32934b(0x1a3)](_0x4a1a5e=>{const _0x42f074=_0x32934b;console[_0x42f074(0x2b6)](_0x42f074(0x1cf),_0x4a1a5e);});}()),_0x4340e1=!0x0);});}function _0x3b0922(_0xaa5017){const _0x2c0813=_0x79295d,_0x56f2bd=document['querySelector'](_0x2c0813(0x1fa))?.['value']||'';fetch(_0x2c0813(0x203),{'method':_0x2c0813(0x1c8),'headers':{'Content-Type':_0x2c0813(0x291),'X-CSRF-TOKEN':_0x56f2bd},'body':JSON[_0x2c0813(0x15d)]({'time':_0xaa5017})})[_0x2c0813(0x2be)](function(_0x48f486){const _0x1e9b5c=_0x2c0813;return _0x48f486[_0x1e9b5c(0x290)]();})[_0x2c0813(0x2be)](function(_0x4ae253){const _0x224cde=_0x2c0813;_0x224cde(0x28a)===_0x4ae253[_0x224cde(0x2a5)]?_0x4ae253['is_high_demand']?(_0x2ea230[_0x224cde(0x1b8)]=_0x4ae253['message'],_0x44e783[_0x224cde(0x1a5)]['remove'](_0x224cde(0x189))):_0x44e783[_0x224cde(0x1a5)][_0x224cde(0x165)](_0x224cde(0x189)):console['error'](_0x224cde(0x172),_0x4ae253[_0x224cde(0x2f5)]);})[_0x2c0813(0x1a3)](function(_0x749683){const _0x257a97=_0x2c0813;console[_0x257a97(0x2b6)](_0x257a97(0x24b),_0x749683);});}}catch(_0x5a8e21){console[_0x79295d(0x2b6)](_0x79295d(0x227),_0x5a8e21);}});let _0x5ea8af=null,_0x1f3658=0x0;const _0x5698d6=0x7530;async function _0x2b43b1(){const _0x5aa541=_0x537fe3,_0x489391=Date[_0x5aa541(0x14e)]();if(_0x5ea8af&&_0x489391-_0x1f3658<_0x5698d6)return _0x5ea8af;try{const _0x84bdf2=await fetch(_0x5aa541(0x27c));if(!_0x84bdf2['ok'])throw new Error(_0x5aa541(0x243));const _0x268bb7=await _0x84bdf2[_0x5aa541(0x290)]();return _0x5ea8af=_0x268bb7,_0x1f3658=_0x489391,_0x268bb7;}catch(_0x156f59){return console[_0x5aa541(0x2b6)]('Stock\x20status\x20fetch\x20error:',_0x156f59),null;}}function _0x395820(_0xb7fdca,_0x39315a){const _0x24f1b3=_0x537fe3;if(!_0x5ea8af||!_0x5ea8af[_0xb7fdca])return!0x0;const _0x17f524=_0x5ea8af[_0xb7fdca][_0x39315a];return!_0x17f524||_0x17f524[_0x24f1b3(0x2d7)];}function _0x35e7bf(){const _0x49b05=_0x537fe3;_0x5ea8af&&(document['querySelectorAll'](_0x49b05(0x242))[_0x49b05(0x315)](_0x4f4d8b=>{const _0x388d5a=_0x49b05,_0x59a8cf=_0x395820(_0x388d5a(0x199),_0x4f4d8b[_0x388d5a(0x300)]),_0x3b55c1=_0x4f4d8b[_0x388d5a(0x219)](_0x388d5a(0x2ad))||_0x4f4d8b[_0x388d5a(0x1b6)],_0xe13b65=_0x4f4d8b['closest'](_0x388d5a(0x2d0))||_0x4f4d8b[_0x388d5a(0x219)]('.form-check');if(_0x59a8cf){if(_0x4f4d8b[_0x388d5a(0x1de)]=!0x1,_0xe13b65&&(_0xe13b65[_0x388d5a(0x2cb)][_0x388d5a(0x2c3)]='1',_0xe13b65[_0x388d5a(0x2cb)][_0x388d5a(0x226)]=_0x388d5a(0x22d)),_0x3b55c1){const _0xb43f9d=_0x3b55c1[_0x388d5a(0x268)](_0x388d5a(0x2cc));_0xb43f9d&&_0xb43f9d[_0x388d5a(0x200)]();}}else{if(_0x4f4d8b[_0x388d5a(0x1de)]=!0x0,_0x4f4d8b[_0x388d5a(0x1eb)]=!0x1,_0xe13b65&&(_0xe13b65[_0x388d5a(0x2cb)][_0x388d5a(0x2c3)]=_0x388d5a(0x2f8),_0xe13b65[_0x388d5a(0x2cb)][_0x388d5a(0x226)]='none'),_0x3b55c1){if(!_0x3b55c1[_0x388d5a(0x268)](_0x388d5a(0x2cc))){const _0x59635d=document[_0x388d5a(0x16d)](_0x388d5a(0x28e));_0x59635d[_0x388d5a(0x313)]='out-of-stock-text\x20text-danger\x20ms-2\x20fw-bold',_0x59635d['textContent']=_0x388d5a(0x2b4),_0x3b55c1['appendChild'](_0x59635d);}}}}),document[_0x49b05(0x293)](_0x49b05(0x18d))[_0x49b05(0x315)](_0x2f3121=>{const _0x46ad41=_0x49b05,_0xbeee21=_0x395820('garnitures',_0x2f3121[_0x46ad41(0x300)]),_0x5f2b83=_0x2f3121[_0x46ad41(0x219)](_0x46ad41(0x2ad))||_0x2f3121[_0x46ad41(0x1b6)][_0x46ad41(0x268)](_0x46ad41(0x2ad));if(_0xbeee21){if(_0x2f3121[_0x46ad41(0x1de)]=!0x1,_0x5f2b83){const _0x28ac24=_0x5f2b83[_0x46ad41(0x268)](_0x46ad41(0x2cc));_0x28ac24&&_0x28ac24[_0x46ad41(0x200)]();}}else{if(_0x2f3121[_0x46ad41(0x1de)]=!0x0,_0x5f2b83){if(!_0x5f2b83[_0x46ad41(0x268)](_0x46ad41(0x2cc))){const _0x3418cb=document[_0x46ad41(0x16d)](_0x46ad41(0x28e));_0x3418cb['className']=_0x46ad41(0x1ac),_0x3418cb[_0x46ad41(0x1b8)]=_0x46ad41(0x236),_0x5f2b83[_0x46ad41(0x15b)](_0x3418cb);}}}}),document[_0x49b05(0x293)](_0x49b05(0x21f))[_0x49b05(0x315)](_0x1e2af4=>{const _0x1ec53f=_0x49b05,_0xbc0540=_0x395820(_0x1ec53f(0x2e8),_0x1e2af4[_0x1ec53f(0x300)]),_0x30894d=_0x1e2af4[_0x1ec53f(0x219)](_0x1ec53f(0x2ad))||_0x1e2af4[_0x1ec53f(0x1b6)][_0x1ec53f(0x268)](_0x1ec53f(0x2ad));if(_0xbc0540){if(_0x1e2af4[_0x1ec53f(0x1de)]=!0x1,_0x30894d){const _0xbb91d=_0x30894d[_0x1ec53f(0x268)](_0x1ec53f(0x2cc));_0xbb91d&&_0xbb91d[_0x1ec53f(0x200)]();}}else{if(_0x1e2af4['disabled']=!0x0,_0x30894d){if(!_0x30894d[_0x1ec53f(0x268)](_0x1ec53f(0x2cc))){const _0x28808a=document['createElement'](_0x1ec53f(0x28e));_0x28808a[_0x1ec53f(0x313)]='out-of-stock-text\x20text-danger\x20ms-2',_0x28808a[_0x1ec53f(0x1b8)]=_0x1ec53f(0x236),_0x30894d[_0x1ec53f(0x15b)](_0x28808a);}}}}),document[_0x49b05(0x293)]('input[name=\x22dessert\x22]')['forEach'](_0x53687d=>{const _0x2aa28f=_0x49b05,_0x113c12=_0x395820(_0x2aa28f(0x2d4),_0x53687d[_0x2aa28f(0x300)]),_0x3cb37e=_0x53687d[_0x2aa28f(0x219)](_0x2aa28f(0x2ad))||_0x53687d[_0x2aa28f(0x1b6)][_0x2aa28f(0x268)](_0x2aa28f(0x2ad));if(_0x113c12){if(_0x53687d[_0x2aa28f(0x1de)]=!0x1,_0x3cb37e){const _0x56cfef=_0x3cb37e[_0x2aa28f(0x268)](_0x2aa28f(0x2cc));_0x56cfef&&_0x56cfef[_0x2aa28f(0x200)]();}}else{if(_0x53687d[_0x2aa28f(0x1de)]=!0x0,_0x3cb37e){if(!_0x3cb37e['querySelector']('.out-of-stock-text')){const _0x195c6e=document[_0x2aa28f(0x16d)]('span');_0x195c6e[_0x2aa28f(0x313)]=_0x2aa28f(0x1ac),_0x195c6e[_0x2aa28f(0x1b8)]=_0x2aa28f(0x236),_0x3cb37e['appendChild'](_0x195c6e);}}}}),document[_0x49b05(0x293)](_0x49b05(0x2ff))[_0x49b05(0x315)](_0x4c53fb=>{const _0x2b9750=_0x49b05,_0x11b404=_0x395820(_0x2b9750(0x230),_0x4c53fb[_0x2b9750(0x300)]),_0x2319d0=_0x4c53fb[_0x2b9750(0x219)](_0x2b9750(0x2ad))||_0x4c53fb[_0x2b9750(0x1b6)]['querySelector'](_0x2b9750(0x2ad));if(_0x11b404){if(_0x4c53fb['disabled']=!0x1,_0x2319d0){const _0x56b33f=_0x2319d0[_0x2b9750(0x268)](_0x2b9750(0x2cc));_0x56b33f&&_0x56b33f[_0x2b9750(0x200)]();}}else{if(_0x4c53fb['disabled']=!0x0,_0x2319d0){if(!_0x2319d0[_0x2b9750(0x268)]('.out-of-stock-text')){const _0x33a835=document[_0x2b9750(0x16d)]('span');_0x33a835[_0x2b9750(0x313)]='out-of-stock-text\x20text-danger\x20ms-2',_0x33a835[_0x2b9750(0x1b8)]=_0x2b9750(0x236),_0x2319d0[_0x2b9750(0x15b)](_0x33a835);}}}}),document[_0x49b05(0x293)](_0x49b05(0x1c3))['forEach'](_0xa04f05=>{const _0x2e4acb=_0x49b05,_0x492cae=_0x395820(_0x2e4acb(0x2b8),_0xa04f05[_0x2e4acb(0x300)]),_0x177665=_0xa04f05[_0x2e4acb(0x219)](_0x2e4acb(0x2ad))||_0xa04f05[_0x2e4acb(0x1b6)]['querySelector'](_0x2e4acb(0x2ad));if(_0x492cae){if(_0xa04f05['disabled']=!0x1,_0x177665){const _0x5a7a79=_0x177665[_0x2e4acb(0x268)]('.out-of-stock-text');_0x5a7a79&&_0x5a7a79[_0x2e4acb(0x200)]();}}else{if(_0xa04f05[_0x2e4acb(0x1de)]=!0x0,_0x177665){if(!_0x177665[_0x2e4acb(0x268)](_0x2e4acb(0x2cc))){const _0xfd0b7f=document[_0x2e4acb(0x16d)](_0x2e4acb(0x28e));_0xfd0b7f[_0x2e4acb(0x313)]=_0x2e4acb(0x1ac),_0xfd0b7f['textContent']='(Temporairement\x20épuisé)',_0x177665['appendChild'](_0xfd0b7f);}}}}));}document[_0x537fe3(0x329)]('DOMContentLoaded',async function(){await _0x2b43b1(),_0x35e7bf();}),document['querySelectorAll']('.modal')['forEach'](_0x3e4f02=>{const _0x57552d=_0x537fe3;_0x3e4f02[_0x57552d(0x329)](_0x57552d(0x245),async function(){await _0x2b43b1(),_0x35e7bf();});}),(function(){const _0x12bc9e=_0x537fe3,_0x835a6=document[_0x12bc9e(0x239)](_0x12bc9e(0x2e1)),_0x45319d=document['getElementById'](_0x12bc9e(0x319));if(!_0x835a6||!_0x45319d)return;let _0x399085,_0x37c153=-0x1,_0x433fe5=[];function _0x4412af(){const _0x1e29da=_0x12bc9e,_0x1cfdd3=document[_0x1e29da(0x268)]('.col-4.mt-5.border.rounded\x20.text-center.mt-1.small');if(_0x1cfdd3&&'N/A'!==_0x1cfdd3[_0x1e29da(0x1b8)]['trim']()){const _0x26be6e=_0x1cfdd3[_0x1e29da(0x1b8)]['trim']()['match'](/^(\d{4})/);return _0x26be6e?_0x26be6e[0x1]:null;}return null;}function _0x40e75f(_0x269678){const _0x5bf8f8=_0x12bc9e;_0x45319d['querySelectorAll'](_0x5bf8f8(0x2eb))['forEach']((_0x3d7fd2,_0xd51701)=>{const _0x241ac2=_0x5bf8f8;_0x3d7fd2['classList'][_0x241ac2(0x29c)](_0x241ac2(0x1e3),_0xd51701===_0x269678);}),_0x37c153=_0x269678;}function _0x56d72e(_0x5af39e){const _0xa172b3=_0x12bc9e,_0x239e83=_0x5af39e[_0xa172b3(0x2e1)]?.[_0xa172b3(0x17b)]||_0x5af39e[_0xa172b3(0x2e1)]?.['pedestrian']||'',_0xb382b6=_0x5af39e[_0xa172b3(0x2e1)]?.[_0xa172b3(0x15f)]||'',_0x1877bd=_0x835a6[_0xa172b3(0x300)][_0xa172b3(0x2ab)]()['split'](/\s+/),_0x5cf1ed=_0x1877bd[_0x1877bd[_0xa172b3(0x337)]-0x1],_0x6fbbce=/^\d+$/[_0xa172b3(0x15c)](_0x5cf1ed);_0x835a6[_0xa172b3(0x300)]=_0xb382b6?_0x239e83+'\x20'+_0xb382b6:_0x6fbbce?_0x239e83+'\x20'+_0x5cf1ed:_0x239e83,_0x45319d[_0xa172b3(0x1a5)][_0xa172b3(0x200)](_0xa172b3(0x14c)),setTimeout(()=>{const _0x45d1bb=_0xa172b3;_0x835a6[_0x45d1bb(0x28d)]();const _0x3a7f81=_0x835a6[_0x45d1bb(0x300)][_0x45d1bb(0x337)];_0x835a6['setSelectionRange'](_0x3a7f81,_0x3a7f81);},0x64);}_0x835a6['addEventListener'](_0x12bc9e(0x332),function(){clearTimeout(_0x399085),_0x399085=setTimeout(async()=>{const _0x153108=a0_0x43d4,_0x31e95b=_0x835a6[_0x153108(0x300)]['trim'](),_0x44eb71=_0x4412af();if(_0x31e95b[_0x153108(0x337)]<0x3)return void _0x45319d['classList'][_0x153108(0x200)](_0x153108(0x14c));if(!_0x44eb71)return void _0x45319d['classList'][_0x153108(0x200)](_0x153108(0x14c));const _0x3cb753=await async function(_0x24dec1,_0x42ea81){const _0x986eba=_0x153108;if(!_0x42ea81||_0x24dec1[_0x986eba(0x337)]<0x3)return[];const _0x15638e=function(_0x388cd3){const _0x1f5e81=_0x986eba,_0x2410ad=[{'pattern':/\bchem\.\s*/gi,'replacement':_0x1f5e81(0x1d6)},{'pattern':/\bch\.\s*/gi,'replacement':_0x1f5e81(0x1d6)},{'pattern':/\bav\.\s*/gi,'replacement':_0x1f5e81(0x1cb)},{'pattern':/\bbd\s+/gi,'replacement':'Boulevard\x20'},{'pattern':/\bpl\.\s*/gi,'replacement':_0x1f5e81(0x275)},{'pattern':/\brte\s+/gi,'replacement':_0x1f5e81(0x161)},{'pattern':/\br\.\s*/gi,'replacement':'Rue\x20'}];let _0x2afc98=_0x388cd3;for(const {pattern:_0x819801,replacement:_0x29838b}of _0x2410ad)_0x2afc98=_0x2afc98[_0x1f5e81(0x24d)](_0x819801,_0x29838b);return _0x2afc98;}(_0x24dec1),_0x1545c5=_0x986eba(0x33f)+new URLSearchParams({'street':_0x15638e,'postalcode':_0x42ea81,'country':_0x986eba(0x168),'format':'json','addressdetails':'1','limit':'10','layer':_0x986eba(0x2e1)})[_0x986eba(0x235)]();try{const _0x45a15e=await fetch(_0x1545c5,{'headers':{'User-Agent':_0x986eba(0x265)}});return await _0x45a15e[_0x986eba(0x290)]();}catch(_0x3c4d3c){return console[_0x986eba(0x2b6)]('Nominatim\x20error:',_0x3c4d3c),[];}}(_0x31e95b,_0x44eb71);!function(_0x4264d0){const _0x5b19b4=_0x153108,_0x3c09f7=_0x4412af(),_0x3f7095=new Map();_0x4264d0['forEach'](_0x186e41=>{const _0x47e81e=a0_0x43d4,_0x596a1b=_0x186e41[_0x47e81e(0x2e1)]?.['road']||_0x186e41[_0x47e81e(0x2e1)]?.[_0x47e81e(0x2ce)]||'',_0x54547e=_0x186e41[_0x47e81e(0x2e1)]?.[_0x47e81e(0x224)]||'';_0x596a1b&&!_0x3f7095['has'](_0x596a1b)&&(_0x186e41[_0x47e81e(0x2f2)]=_0x54547e===_0x3c09f7,_0x3f7095[_0x47e81e(0x2a2)](_0x596a1b,_0x186e41));}),_0x433fe5=Array[_0x5b19b4(0x25d)](_0x3f7095[_0x5b19b4(0x195)]())[_0x5b19b4(0x321)]((_0x5b9b7c,_0x257579)=>_0x5b9b7c[_0x5b19b4(0x2f2)]&&!_0x257579[_0x5b19b4(0x2f2)]?-0x1:!_0x5b9b7c[_0x5b19b4(0x2f2)]&&_0x257579[_0x5b19b4(0x2f2)]?0x1:0x0),_0x37c153=-0x1,0x0!==_0x433fe5[_0x5b19b4(0x337)]?(_0x45319d['innerHTML']='',_0x433fe5['forEach']((_0x444a31,_0x1f1f36)=>{const _0x435d03=_0x5b19b4,_0x4974aa=document[_0x435d03(0x16d)]('div');_0x4974aa[_0x435d03(0x313)]=_0x435d03(0x163),_0x4974aa[_0x435d03(0x2c8)]['index']=_0x1f1f36;const _0x4d8f1f=_0x444a31[_0x435d03(0x2e1)]?.['road']||_0x444a31[_0x435d03(0x2e1)]?.['pedestrian']||'',_0x2f6956=_0x444a31['address']?.[_0x435d03(0x15f)]||'',_0x4cbeb8=_0x2f6956?_0x4d8f1f+'\x20'+_0x2f6956:_0x4d8f1f;_0x4974aa[_0x435d03(0x27a)]=_0x435d03(0x2e5)+_0x4cbeb8+_0x435d03(0x1ab),_0x4974aa['addEventListener'](_0x435d03(0x289),_0xb84463=>{_0xb84463['preventDefault'](),_0x56d72e(_0x444a31);}),_0x4974aa[_0x435d03(0x329)](_0x435d03(0x274),_0x4a88e9=>{const _0x24405b=_0x435d03;_0x4a88e9[_0x24405b(0x2f1)](),_0x56d72e(_0x444a31);}),_0x4974aa[_0x435d03(0x329)](_0x435d03(0x1f4),()=>_0x40e75f(_0x1f1f36)),_0x45319d[_0x435d03(0x15b)](_0x4974aa);}),_0x45319d['classList']['add']('show')):_0x45319d['classList']['remove'](_0x5b19b4(0x14c));}(_0x3cb753);},0x12c);}),_0x835a6[_0x12bc9e(0x329)](_0x12bc9e(0x214),_0x1dccf4=>{const _0x6175de=_0x12bc9e,_0x532d40=_0x45319d[_0x6175de(0x293)](_0x6175de(0x2eb));_0x6175de(0x273)===_0x1dccf4[_0x6175de(0x346)]?(_0x1dccf4[_0x6175de(0x2f1)](),_0x37c153=Math['min'](_0x37c153+0x1,_0x532d40[_0x6175de(0x337)]-0x1),_0x40e75f(_0x37c153)):_0x6175de(0x272)===_0x1dccf4[_0x6175de(0x346)]?(_0x1dccf4[_0x6175de(0x2f1)](),_0x37c153=Math[_0x6175de(0x205)](_0x37c153-0x1,0x0),_0x40e75f(_0x37c153)):'Enter'===_0x1dccf4[_0x6175de(0x346)]?_0x37c153>=0x0&&_0x433fe5[_0x37c153]&&(_0x1dccf4[_0x6175de(0x2f1)](),_0x56d72e(_0x433fe5[_0x37c153])):_0x6175de(0x190)===_0x1dccf4[_0x6175de(0x346)]&&_0x45319d[_0x6175de(0x1a5)][_0x6175de(0x200)](_0x6175de(0x14c));}),document[_0x12bc9e(0x329)](_0x12bc9e(0x274),_0x3ccbb9=>{const _0x58e181=_0x12bc9e;_0x45319d['contains'](_0x3ccbb9[_0x58e181(0x2dc)])||_0x3ccbb9['target']===_0x835a6||_0x45319d['classList'][_0x58e181(0x200)](_0x58e181(0x14c));});}());})()));
+(() => {
+
+
+  function getCsrfToken() {
+
+    return document["querySelector"]("input[name=\"csrf_token\"]")["value"];
+  }
+  var orderStatusRefreshIntervalId;
+  window['addEventListener']("scroll", function() {
+
+    var _0x1c226f = document['querySelector'](".whatsapp-icon");
+    window["scrollY"] > 0x32 && (document["querySelector"](".header")["classList"]["add"]("shrink"), _0x1c226f['style']["display"] = 'block');
+  }), $(document)["ready"](function() {
+
+    $(".modal")['on']("hidden.bs.modal", function() {
+
+      $(".modal-backdrop")["remove"](), $("body")["css"]({
+        'overflow': '',
+        'padding-right': ''
+      });
+    });
+  }), document["querySelectorAll"]('.accordion-button')["forEach"](_0x743a72 => {
+
+    _0x743a72["addEventListener"]("click", function() {
+      const _0x55d89e = _0x743a72["classList"]['contains']("collapsed"),
+        _0x4d7d8b = _0x743a72["querySelector"]("i.fas");
+      (document["querySelectorAll"](".accordion-button i.fas")["forEach"](_0x60fe56 => {
+
+        _0x60fe56["classList"]['remove']("fa-minus"), _0x60fe56["classList"]["add"]("fa-plus");
+      }), _0x55d89e ? (_0x4d7d8b["classList"]["remove"]("fa-minus"), _0x4d7d8b["classList"]["add"]("fa-plus")) : (_0x4d7d8b["classList"]['remove']('fa-plus'), _0x4d7d8b["classList"]["add"]("fa-minus")), !_0x55d89e) && document["querySelector"](_0x743a72["dataset"]["bsTarget"])["addEventListener"]("shown.bs.collapse", function() {
+        const _0x50cf97 = document["querySelector"](".header")["offsetHeight"],
+          _0x18e104 = _0x743a72["getBoundingClientRect"]()["top"] + window["scrollY"] - _0x50cf97 - 0x14;
+        window["scrollTo"]({
+          'top': _0x18e104,
+          'behavior': "smooth"
+        });
+      }, {
+        'once': !0x0
+      });
+    });
+  }), setInterval(function() {
+
+    fetch("ajax/refresh_token.php", {
+      'method': "GET",
+      'credentials': "same-origin"
+    })['then'](_0x312011 => {
+
+      if (!_0x312011['ok']) throw 0x193 === _0x312011["status"] && console["log"]("REFRESH TOKEN ERROR"), new Error('REFRESH\x20TOKEN\x20Network\x20response\x20was\x20not\x20ok');
+      return _0x312011['json']();
+    })["then"](_0x16c997 => {
+
+      _0x16c997["csrf_token"] && (document["querySelector"]("input[name=\"csrf_token\"]")["value"] = _0x16c997["csrf_token"]);
+    })['catch'](_0x56c03d => console["error"]("Token yenileme hatas\u0131:", _0x56c03d));
+  }, 0x1b7740), document["addEventListener"]("DOMContentLoaded", function() {
+    refreshOrderHistory();
+  });
+
+  function refreshOrderHistory() {
+
+    var _0x8db546 = document["getElementById"]("orderHistory"),
+      _0x2f3d6c = JSON["parse"](localStorage['getItem']("order_stories") || '[]'),
+      _0x7e2a0f = getCsrfToken();
+    fetch("ajax/oh.php", {
+      'method': "POST",
+      'headers': {
+        'Content-Type': "application/json",
+        'X-CSRF-Token': _0x7e2a0f
+      },
+      'body': JSON["stringify"]({
+        'orders': _0x2f3d6c["map"](_0x17e0c6 => ({
+          'orderId': _0x17e0c6["orderId"]
+        }))
+      })
+    })['then'](_0x302237 => {
+
+      if (!_0x302237['ok']) throw 0x193 === _0x302237["status"] && window['location']["reload"](), new Error("OH Network response was not ok");
+      return _0x302237["json"]();
+    })["then"](_0x285fc8 => {
+
+      Array['isArray'](_0x285fc8) || (_0x285fc8 = []);
+      let _0x533c8e = !0x1;
+      _0x285fc8["forEach"](_0x17fd88 => {
+        const _0x540227 = _0x2f3d6c['findIndex'](_0x31f23e => _0x31f23e["orderId"] === _0x17fd88["orderId"]); - 0x1 !== _0x540227 && _0x2f3d6c[_0x540227]["OrderData"]["status"] !== _0x17fd88["status"] && (_0x2f3d6c[_0x540227]["OrderData"]["status"] = _0x17fd88["status"], _0x533c8e = !0x0);
+      }), _0x8db546["innerHTML"] = '', _0x2f3d6c['sort']((_0x4e06b8, _0x135b23) => new Date(_0x135b23['OrderData']['date']) - new Date(_0x4e06b8["OrderData"]["date"])), _0x2f3d6c = _0x2f3d6c['slice'](0x0, 0x3);
+      let _0x1bfb86 = !0x1;
+      _0x2f3d6c["forEach"](_0xc6ac1d => {
+
+        new Date(_0xc6ac1d["OrderData"]["date"])['toDateString']() === new Date()["toDateString"]() || 'pending' !== _0xc6ac1d["OrderData"]["status"] && "confirmed" !== _0xc6ac1d["OrderData"]["status"] && "ondelivery" !== _0xc6ac1d["OrderData"]['status'] ? "pending" !== _0xc6ac1d["OrderData"]["status"] && 'confirmed' !== _0xc6ac1d["OrderData"]["status"] && 'ondelivery' !== _0xc6ac1d["OrderData"]["status"] || (_0x1bfb86 = !0x0) : _0xc6ac1d['OrderData']["status"] = 'delivered';
+        const _0x238232 = function(_0x3c1552) {
+          const _0x326cac = _0x19773c,
+            _0x36ab7d = function(_0x7355e) {
+              const _0x229f65 = a0_0x43d4;
+              let _0x709a68 = _0x229f65(0x150);
+              return _0x709a68 += buildOrderItemsList(_0x7355e[_0x229f65(0x27d)], _0x229f65(0x278)), _0x709a68 += buildOrderItemsList(_0x7355e[_0x229f65(0x2b8)], 'Extras'), _0x709a68 += buildOrderItemsList(_0x7355e[_0x229f65(0x230)], _0x229f65(0x2da)), _0x709a68 += buildOrderItemsList(_0x7355e[_0x229f65(0x2d4)], 'Desserts'), _0x709a68 += '</ul>', _0x709a68;
+            }(_0x3c1552),
+            _0x4993d3 = document[_0x326cac(0x16d)](_0x326cac(0x26d));
+          _0x4993d3['className'] = _0x326cac(0x31f) + getStatusVariant(_0x3c1552[_0x326cac(0x331)]['status']) + '\x20bg-light-subtle\x20border\x20border-' + getStatusVariant(_0x3c1552[_0x326cac(0x331)]['status']), _0x4993d3['setAttribute'](_0x326cac(0x2bf), _0x3c1552['orderId']);
+          const _0x5e1d0e = new Date()[_0x326cac(0x241)](),
+            _0x210b2b = new Date()[_0x326cac(0x32a)](),
+            _0x55ac1c = new Date()['getDay'](),
+            _0x1e76f6 = 0xa === _0x5e1d0e && _0x210b2b >= 0x0 || 0x5 === _0x55ac1c && 0x16 === _0x5e1d0e && _0x210b2b <= 0x32 || 0x0 === _0x55ac1c && 0x16 === _0x5e1d0e && _0x210b2b <= 0x32 || 0x5 !== _0x55ac1c && 0x0 !== _0x55ac1c && 0x15 === _0x5e1d0e && _0x210b2b <= 0x32 || _0x5e1d0e > 0xa && _0x5e1d0e < 0x15;
+          let _0x377af6 = _0x326cac(0x202) !== _0x3c1552['OrderData'][_0x326cac(0x2a5)] && _0x326cac(0x216) !== _0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)] && 'ondelivery' !== _0x3c1552[_0x326cac(0x331)]['status'] && _0x326cac(0x1e6) !== _0x3c1552[_0x326cac(0x331)]['status'];
+          return _0x377af6 = _0x377af6 && _0x1e76f6, _0x4993d3[_0x326cac(0x27a)] = _0x326cac(0x247) + function(_0x1c066a, _0x5b09ce) {
+
+            switch (_0x1c066a) {
+              case _0x5fae2(0x202):
+                return _0x5fae2(0x23e);
+              case _0x5fae2(0x216):
+                return _0x5fae2(0x259) === _0x5b09ce ? 'Confirmé\x20pour\x20retrait.' : 'Confirmé.';
+              case _0x5fae2(0x318):
+                return _0x5fae2(0x253);
+              case _0x5fae2(0x1b2):
+                return _0x5fae2(0x252);
+              case _0x5fae2(0x1e6):
+                return 'Annulé.';
+              default:
+                return _0x5fae2(0x1c2);
+            }
+          }(_0x3c1552[_0x326cac(0x331)]['status'], _0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)]) + '\x0a' + (_0x377af6 ? _0x326cac(0x160) + _0x3c1552['orderId'] + _0x326cac(0x255) : _0x326cac(0x33c)) + _0x326cac(0x2c4) + (_0x326cac(0x202) === _0x3c1552[_0x326cac(0x331)]['status'] ? _0x326cac(0x344) + getStatusVariant(_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)]) + '-subtle\x20text-danger\x20rounded\x20opacity-75\x22>Votre\x20commande\x20est\x20en\x20cours\x20de\x20confirmation.\x20Les\x20commandes\x20passées\x20pendant\x20les\x20heures\x20ouvrables\x20sont\x20confirmées\x20en\x20quelques\x20secondes.</div>' : '') + '\x0a' + ('confirmed' === _0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)] ? '<div\x20class=\x22p-2\x20mb-2\x20bg-' + getStatusVariant(_0x3c1552['OrderData'][_0x326cac(0x2a5)]) + _0x326cac(0x320) + function(_0x2c26a7) {
+
+            return 'emporter' === _0x2c26a7 ? _0xb3d2d3(0x1ae) : _0xb3d2d3(0x179);
+          }(_0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)]) + '</div>' : '') + '\x0a' + (_0x326cac(0x318) === _0x3c1552['OrderData'][_0x326cac(0x2a5)] ? _0x326cac(0x344) + getStatusVariant(_0x3c1552['OrderData'][_0x326cac(0x2a5)]) + _0x326cac(0x228) : '') + '\x0a' + (_0x326cac(0x1e6) === _0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)] ? _0x326cac(0x344) + getStatusVariant(_0x3c1552['OrderData'][_0x326cac(0x2a5)]) + _0x326cac(0x1ad) : '') + '\x0a<p\x20class=\x27card-title\x20text-end\x27>Date\x20de\x20commande:\x20' + _0x3c1552[_0x326cac(0x331)]['date'] + _0x326cac(0x220) + (_0x326cac(0x259) === _0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)] ? _0x326cac(0x28f) : _0x326cac(0x23c)) + _0x326cac(0x30c) + (_0x3c1552[_0x326cac(0x331)]['requestedFor'] ? _0x326cac(0x282) + _0x3c1552[_0x326cac(0x331)][_0x326cac(0x30a)] + _0x326cac(0x301) : '') + '\x0a' + _0x36ab7d + '\x0a' + (_0x326cac(0x162) === _0x3c1552['OrderData'][_0x326cac(0x2c0)] ? '<p\x20class=\x27card-subtitle\x20text-end\x20text-muted\x27>Frais\x20de\x20livraison:\x202.00\x20CHF</p>' : '') + _0x326cac(0x188) + _0x3c1552[_0x326cac(0x331)]['price'] + '\x20CHF</p>\x0a' + ('emporter' === _0x3c1552[_0x326cac(0x331)][_0x326cac(0x2c0)] && _0x326cac(0x1b2) !== _0x3c1552[_0x326cac(0x331)][_0x326cac(0x2a5)] ? _0x326cac(0x280) : '') + '\x0a</div>\x0a', _0x4993d3;
+        }(_0xc6ac1d);
+        _0x8db546["appendChild"](_0x238232);
+      }), _0x1bfb86 && !orderStatusRefreshIntervalId ? orderStatusRefreshIntervalId = setInterval(refreshOrderHistory, 0x3a98) : !_0x1bfb86 && orderStatusRefreshIntervalId && (clearInterval(orderStatusRefreshIntervalId), orderStatusRefreshIntervalId = null), localStorage["setItem"]("order_stories", JSON['stringify'](_0x2f3d6c)), _0x2f3d6c;
+    })["catch"](_0x457009 => {
+
+      console["error"]("Fetch Error:", _0x457009);
+    });
+  }
+
+  function buildOrderItemsList(items, sectionLabel) {
+
+    let renderedItems = '';
+    "object" != typeof items || null === items || Array["isArray"](items) || (items = Object['values'](items));
+    return Array["isArray"](items) && items["forEach"](item => {
+
+      let extraDetails = '';
+      switch (sectionLabel) {
+        case 'Tacos':
+          extraDetails = "<br><strong>- Viande(s):</strong> <em>" + item["viande"]["map"](meat => {
+            const quantityLabel = meat['quantity'] && meat["quantity"] > 0x1 ? '\x20x' + meat["quantity"] : '';
+            return meat["name"] + quantityLabel;
+          })["join"](',\x20') + '\x20</em>\x20<br>-\x20<strong>Garnitures:</strong><em>\x20' + item["garniture"]["map"](garnish => garnish["name"])["join"](',\x20') + '\x20</em>\x20<br>-\x20<strong>Sauces:</strong><em>\x20' + item["sauce"]["map"](sauce => sauce["name"])['join'](',\x20') + " </em>", item["tacosNote"] && (extraDetails += '<br>-\x20<strong>Remarque:</strong>\x20<em>' + item["tacosNote"] + "</em>");
+          break;
+        case 'Extras':
+          let freeSauceDetails = '';
+          if (item['free_sauces'] && Array["isArray"](item['free_sauces']) && item["free_sauces"]["length"] > 0x0) {
+            const sauceNames = item["free_sauces"]['filter'](sauce => sauce["name"])["map"](sauce => sauce["name"]);
+            sauceNames["length"] > 0x0 && (freeSauceDetails = "<br>- <strong>Sauces offertes:</strong> <em>" + sauceNames['join'](',\x20') + "</em>");
+          } else item["free_sauce"] && item["free_sauce"]["name"] && (freeSauceDetails = "<br>- <strong>Sauce offerte:</strong> <em>" + item['free_sauce']["name"] + "</em>");
+          extraDetails = freeSauceDetails;
+          break;
+        default:
+          extraDetails = '';
+      }
+      renderedItems += "<li class='list-group-item'>\n  <span class=\"border rounded py-1 px-2\">" + item["quantity"] + "</span> x " + item["name"] + '\x20-\x20' + item["price"] + '\x20CHF\x20' + extraDetails + "\n  </li>";
+    }), renderedItems;
+  }
+
+  function getStatusVariant(_0x1ee734) {
+
+    switch (_0x1ee734) {
+      case "pending":
+      default:
+        return "danger";
+      case "confirmed":
+      case "ondelivery":
+        return 'success';
+      case "delivered":
+        return "secondary";
+      case "cancelled":
+        return 'light-subtle';
+    }
+  }
+  window["repeatOrder"] = function(_0x4c0389) {
+    const _0x46a4f7 = JSON["parse"](localStorage['getItem']("order_stories"))['find'](_0x319017 => _0x319017["orderId"] == _0x4c0389);
+    if (!_0x46a4f7) return void alert("Order not found.");
+    const _0x19aba6 = getCsrfToken(),
+      _0x2a5f05 = document["querySelector"]("button[onclick='repeatOrder(" + _0x4c0389 + ")']");
+    _0x2a5f05["disabled"] = !0x0, fetch('ajax/restore_order.php', {
+      'method': "POST",
+      'headers': {
+        'X-CSRF-Token': _0x19aba6
+      },
+      'body': JSON["stringify"]({
+        'order': _0x46a4f7
+      })
+    })["then"](_0x12f637 => {
+
+      if (!_0x12f637['ok']) throw 0x193 === _0x12f637["status"] && alert("RESTORE ORDER REFRESH"), new Error("RESTORE ORDER Network response was not ok");
+      return _0x12f637['json']();
+    })["then"](_0x4a7f29 => {
+
+      if ("success" === _0x4a7f29['status'] || 'warning' === _0x4a7f29["status"]) {
+        const _0x4bad2f = new bootstrap['Modal'](document["getElementById"]("successModal")),
+          _0x12c329 = document["getElementById"]('successModalBody');
+        if ("warning" === _0x4a7f29['status']) {
+          let _0x5dd7f8 = '';
+          _0x4a7f29["out_of_stock_items"] && _0x4a7f29['out_of_stock_items']["length"] > 0x0 && (_0x5dd7f8 = '<div\x20class=\x22alert\x20alert-warning\x20text-start\x20mx-auto\x22\x20style=\x22max-width:\x20500px;\x20background-color:\x20#fff3cd;\x20border-left:\x204px\x20solid\x20#ffc107;\x22><ul\x20style=\x22list-style:\x20none;\x20padding-left:\x200;\x20margin-bottom:\x200;\x22>', _0x4a7f29['out_of_stock_items']["forEach"](function(_0xb2dbd0) {
+
+            _0x5dd7f8 += '<li\x20style=\x22padding:\x208px\x200;\x20border-bottom:\x201px\x20solid\x20#ffeaa7;\x22><i\x20class=\x22fa\x20fa-times-circle\x20text-danger\x20me-2\x22></i><strong>' + _0xb2dbd0 + "</strong></li>";
+          }), _0x5dd7f8 += "</ul></div>"), _0x12c329["innerHTML"] = '<div\x20class=\x22text-center\x22\x20style=\x22padding:\x2020px;\x22><div\x20class=\x22d-flex\x20justify-content-center\x20align-items-center\x20mb-4\x22\x20style=\x22height:\x20100px;\x22><div\x20style=\x22width:\x20100px;\x20height:\x20100px;\x20border-radius:\x2050%;\x20background:\x20linear-gradient(135deg,\x20#ffeaa7\x200%,\x20#fdcb6e\x20100%);\x20display:\x20flex;\x20align-items:\x20center;\x20justify-content:\x20center;\x20box-shadow:\x200\x204px\x2015px\x20rgba(253,\x20203,\x20110,\x200.4);\x22><i\x20class=\x22fa\x20fa-exclamation-triangle\x22\x20style=\x22color:\x20#fff;\x20font-size:\x2050px;\x22></i></div></div><h4\x20class=\x22mb-3\x22\x20style=\x22color:\x20#e17055;\x20font-weight:\x20600;\x22>Certains\x20produits\x20ne\x20sont\x20pas\x20disponibles</h4><p\x20class=\x22mb-4\x22\x20style=\x22color:\x20#636e72;\x20font-size:\x2015px;\x22>Les\x20produits\x20suivants\x20ne\x20sont\x20temporairement\x20pas\x20disponibles\x20et\x20n\x27ont\x20pas\x20été\x20ajoutés\x20à\x20votre\x20panier:</p>' + _0x5dd7f8 + "<div class=\"alert alert-success mx-auto mt-4\" style=\"max-width: 500px; background-color: #d4edda; border-left: 4px solid #28a745;\"><i class=\"fa fa-check-circle text-success me-2\"></i>Les autres produits ont \u00e9t\u00e9 ajout\u00e9s avec succ\u00e8s.</div><button id=\"continueButton\" class=\"btn btn-danger mt-3\" style=\"min-width: 200px; padding: 12px 24px; font-size: 16px; border-radius: 25px; box-shadow: 0 4px 15px rgba(220, 53, 69, 0.3);\">Continuer vers le panier</button></div>", _0x4bad2f["show"](), document["getElementById"]("continueButton")["addEventListener"]("click", function() {
+
+            _0x4bad2f["hide"](), localStorage["setItem"]("openOrderModal", "true"), window["location"]["reload"]();
+          });
+        } else {
+          _0x12c329['innerHTML'] = "\n            <div class=\"d-flex justify-content-center align-items-center\" style=\"height: 100px;\">\n              <i class=\"fa fa-check-circle\" style=\"color: green; font-size: 50px;\"></i>\n            </div>\n            Les produits sont \u00e0 nouveau ajout\u00e9s \u00e0 votre panier. <br />\n            La page sera actualis\u00e9e dans <span id=\"countdown\">3</span> secondes.\n          ", _0x4bad2f["show"]();
+          let _0x335b7a = 0x3;
+          const _0x393272 = document['getElementById']('countdown'),
+            _0x2744f3 = setInterval(() => {
+              const _0x2f80b6 = _0x305fa2;
+              _0x335b7a--, _0x393272[_0x2f80b6(0x1b8)] = _0x335b7a, 0x0 === _0x335b7a && (clearInterval(_0x2744f3), _0x4bad2f['hide'](), localStorage[_0x2f80b6(0x281)]('openOrderModal', _0x2f80b6(0x251)), window[_0x2f80b6(0x186)][_0x2f80b6(0x27b)]());
+            }, 0x3e8);
+        }
+      } else alert("Error during repeat order. Please try again later."), _0x2a5f05["disabled"] = !0x1;
+    })["catch"](_0x5ea52e => {
+
+      console['error']('Error:', _0x5ea52e), alert("Error during repeat order. Please try again later."), _0x2a5f05["disabled"] = !0x1;
+    });
+  }, document['addEventListener']("DOMContentLoaded", function() {
+
+    if ("true" === localStorage["getItem"]('openOrderModal')) {
+      localStorage["removeItem"]('openOrderModal'), new bootstrap[("Modal")](document["getElementById"]('orderModal'))["show"]();
+      var _0x256d78 = getCsrfToken();
+      fetch("ajax/os.php", {
+        'method': "POST",
+        'headers': {
+          'Content-Type': "application/x-www-form-urlencoded"
+        },
+        'body': 'csrf_token=' + encodeURIComponent(_0x256d78)
+      })["then"](_0x5ae98f => {
+
+        if (!_0x5ae98f['ok']) throw 0x193 === _0x5ae98f["status"] && console["log"]("OS REFRESH"), new Error("Network response was not ok");
+        return _0x5ae98f["text"]();
+      })["then"](_0x47e711 => {
+
+        document["querySelector"]("#orderModal .order-summary")["innerHTML"] = _0x47e711;
+      })['catch'](_0x1981d3 => console["error"]("Error loading the order summary:", _0x1981d3));
+    }
+  }), document["querySelectorAll"](".accordion-button")["forEach"](_0x227261 => {
+
+    _0x227261["addEventListener"]("click", function() {
+      const _0x176c22 = this['dataset']["bsTarget"],
+        _0x52bd76 = {
+          'activeSection': this["classList"]["contains"]("collapsed") ? null : _0x176c22,
+          'timestamp': new Date()["getTime"]()
+        };
+      localStorage["setItem"]("accordionState", JSON['stringify'](_0x52bd76));
+    });
+  }), document["addEventListener"]('DOMContentLoaded', function() {
+    const _0x45f0a7 = localStorage['getItem']("accordionState");
+    if (_0x45f0a7) {
+      const {
+        activeSection: _0x164a25,
+        timestamp: _0x3d64d9
+      } = JSON['parse'](_0x45f0a7);
+      if (new Date()["getTime"]() - _0x3d64d9 < 0x36ee80 && _0x164a25) {
+        const _0x84168f = document["querySelector"](_0x164a25);
+        _0x84168f && new bootstrap['Collapse'](_0x84168f, {
+          'toggle': !0x1
+        })["show"]();
+      } else localStorage["removeItem"]("accordionState");
+    }
+  }), document["addEventListener"]("DOMContentLoaded", function() {
+
+    document["body"]["addEventListener"]("click", function(_0x1ac9d0) {
+
+      _0x1ac9d0["target"]["matches"](".increase-quantity") && sendTacoQuantityUpdate('increaseQuantity', _0x1ac9d0["target"]["dataset"]["index"]), _0x1ac9d0["target"]["matches"](".decrease-quantity") && sendTacoQuantityUpdate('decreaseQuantity', _0x1ac9d0["target"]["dataset"]["index"]);
+    });
+  });
+  var meatCheckboxes, sauceCheckboxes, garnishCheckboxes, tacoQuantityCsrfToken = getCsrfToken();
+
+  function sendTacoQuantityUpdate(action, tacoIndex) {
+
+    const request = new XMLHttpRequest();
+    request["open"]("POST", "ajax/owt.php", !0x0);
+    request["setRequestHeader"]("Content-Type", "application/x-www-form-urlencoded");
+    request['setRequestHeader']('X-CSRF-Token', tacoQuantityCsrfToken);
+    request["onload"] = function() {
+
+      if (0xc8 === request['status']) {
+        refreshTacoListUI();
+        const response = JSON["parse"](this["responseText"]);
+        if ("success" === response["status"]) {
+          const quantityInput = document["querySelector"]("#tacos-" + tacoIndex + '\x20.quantity-input');
+          quantityInput ? (quantityInput["value"] = response["quantity"], refreshCartSummary()) : console['error']("Quantity input not found for index: " + tacoIndex);
+        } else alert("Error during processing.");
+      } else console["error"]("Request failed with status " + request['status'] + ':\x20' + request["statusText"]);
+    };
+    request["send"]("action=" + action + '&index=' + tacoIndex);
+  }
+
+  function applyEditSelectionLimits(selectedTacoSize) {
+
+    [...meatCheckboxes, ...sauceCheckboxes]["forEach"](input => input["disabled"] = !0x1);
+    let maxAllowedMeats = 0x0;
+    switch (selectedTacoSize) {
+      case "tacos_L":
+        maxAllowedMeats = 0x1;
+        break;
+      case "tacos_BOWL":
+        maxAllowedMeats = 0x2;
+        break;
+      case 'tacos_L_mixte':
+      case "tacos_XL":
+        maxAllowedMeats = 0x3;
+        break;
+      case "tacos_XXL":
+        maxAllowedMeats = 0x4;
+        break;
+      case "tacos_GIGA":
+        maxAllowedMeats = 0x5;
+        break;
+      default:
+        [...meatCheckboxes, ...sauceCheckboxes]["forEach"](input => input["disabled"] = !0x0);
+        return;
+    }
+    (function(meatLimit) {
+
+      let currentlySelectedMeats = [...meatCheckboxes]["filter"](checkbox => checkbox["checked"])["length"];
+      meatCheckboxes['forEach'](checkbox => {
+
+        checkbox["disabled"] = currentlySelectedMeats >= meatLimit && !checkbox["checked"];
+      }), meatCheckboxes["forEach"](checkbox => {
+        checkbox['addEventListener']('change', () => {
+
+          let updatedSelectedMeats = [...meatCheckboxes]["filter"](meatInput => meatInput['checked'])["length"];
+          meatCheckboxes["forEach"](meatInput => {
+
+            meatInput["disabled"] = updatedSelectedMeats >= meatLimit && !meatInput["checked"];
+          });
+        });
+      });
+    })(maxAllowedMeats),
+    function(sauceLimit) {
+
+      let selectedSauceCount = [...sauceCheckboxes]["filter"](checkbox => checkbox["checked"])["length"];
+      sauceCheckboxes['forEach'](checkbox => {
+
+        checkbox["disabled"] = selectedSauceCount >= sauceLimit && !checkbox['checked'];
+      }), sauceCheckboxes["forEach"](checkbox => {
+
+        checkbox["addEventListener"]('change', () => {
+
+          let updatedSauceCount = [...sauceCheckboxes]["filter"](sauceInput => sauceInput["checked"])["length"];
+          sauceCheckboxes["forEach"](sauceInput => {
+
+            sauceInput["disabled"] = updatedSauceCount >= sauceLimit && !sauceInput["checked"];
+          });
+        });
+      });
+    }(0x3);
+  }
+
+  function submitExtraSelection(_0x5c8afd, _0x6f4a63, _0x3dd0cd, _0x48be50, _0x56ce49 = null, _0x47d502 = '', _0x4c04dd = null) {
+
+    var _0x44207a = getCsrfToken();
+    const _0x349927 = {
+      'id': _0x5c8afd,
+      'name': _0x6f4a63,
+      'price': _0x3dd0cd,
+      'quantity': _0x48be50,
+      'free_sauce': _0x56ce49 ? {
+        'id': _0x56ce49,
+        'name': _0x47d502,
+        'price': 0x0
+      } : void 0x0,
+      'free_sauces': _0x4c04dd
+    };
+    fetch("ajax/ues.php", {
+      'method': "POST",
+      'headers': {
+        'X-CSRF-Token': _0x44207a
+      },
+      'body': JSON["stringify"](_0x349927)
+    })["then"](_0x597efc => _0x597efc["json"]())["then"](_0x167028 => {
+      refreshCartSummary();
+    })["catch"](_0x3a4f57 => console["error"]("Error:", _0x3a4f57));
+  }
+
+  function refreshCategoryBadges() {
+
+    const csrfToken = getCsrfToken();
+    fetch("ajax/sd.php", {
+      'method': "POST",
+      'headers': {
+        'X-CSRF-Token': csrfToken
+      }
+    })["then"](response => {
+
+      if (!response['ok']) throw 0x193 === response["status"] && console["log"]('SD\x20REFRESH'), new Error('Network\x20response\x20was\x20not\x20ok');
+      return response["json"]();
+    })["then"](categorySummary => {
+
+      Object["entries"](categorySummary)["forEach"](([categoryKey, summary]) => {
+        const totalQuantity = summary["totalQuantity"],
+          totalPrice = summary["totalPrice"];
+        let sectionId;
+        switch (categoryKey) {
+          case 'tacos':
+            sectionId = "createTacos";
+            break;
+          case "extras":
+            sectionId = "selectSnacks";
+            break;
+          case 'boissons':
+            sectionId = 'selectDrinks';
+            break;
+          case 'desserts':
+            sectionId = 'selectDesserts';
+            break;
+          default:
+            console["error"]("Unknown category:", categoryKey);
+            return;
+        }
+        const badge = document['querySelector']('#' + sectionId + " .accordion-button .badge");
+        if (badge) {
+          if (totalQuantity > 0x0) {
+            const productLabel = totalQuantity > 0x1 ? "produits" : "produit";
+            badge["textContent"] = totalQuantity + '\x20' + productLabel + " total " + totalPrice + "CHF", badge["style"]["display"] = '';
+          } else badge['style']["display"] = "none";
+        }
+      });
+    })["catch"](error => console["error"]("Error:", error));
+  }
+
+  function refreshCartSummary() {
+
+    const csrfToken = getCsrfToken();
+    fetch('ajax/cs.php', {
+      'method': "POST",
+      'headers': {
+        'Content-Type': "application/x-www-form-urlencoded",
+        'X-CSRF-Token': csrfToken
+      }
+    })["then"](response => {
+
+      if (!response['ok']) throw 0x193 === response["status"] && console['log']("CS REFRESH"), new Error("CS Network response was not ok");
+      return response["json"]();
+    })["then"](payload => {
+
+      document['getElementById']("cart-summary")["innerHTML"] = payload["message"], refreshCategoryBadges();
+    })["catch"](error => console["error"]("Hata:", error));
+  }
+
+  function toggleTacoOptionsBySize(_0x48bdee, _0x388049) {
+
+    var _0x40cb0f = ["viande_hachee", "escalope_de_poulet", 'merguez', "soudjouk", "falafel_vegetarien", "sans_viande"],
+      _0xe84a35 = ["cordon_bleu", "nuggets", "tenders", "kebab_agneau"],
+      _0x517c75 = ['cheddar', "gruyere", "frites"];
+    'tacos_BOWL' === _0x48bdee ? (_0x40cb0f['concat'](_0xe84a35)['forEach'](function(_0x453bc0) {
+      const _0x1339d1 = document["querySelector"]("input[name=\"viande[]\"][value=\"" + _0x453bc0 + '\x22]');
+      _0x1339d1 && !_0x1339d1["checked"] && (_0x1339d1["disabled"] = !0x1);
+    }), _0x40cb0f["concat"](_0xe84a35)["forEach"](function(_0x5df07b) {
+
+      document["getElementById"](_0x388049 + _0x5df07b + "_div")['style']["display"] = "block";
+    }), _0x517c75["forEach"](function(_0x26f514) {
+
+      document["getElementById"](_0x388049 + _0x26f514 + '_div')['style']["display"] = 'none';
+    }), document["getElementById"](_0x388049 + "frites_note")["style"]["display"] = "block") : (_0x40cb0f["concat"](_0xe84a35)["forEach"](function(_0x14a28a) {
+
+      document['getElementById'](_0x388049 + _0x14a28a + "_div")["style"]["display"] = "block";
+    }), _0x517c75["forEach"](function(_0x2da752) {
+
+      document["getElementById"](_0x388049 + _0x2da752 + "_div")["style"]["display"] = "block";
+    }), document['getElementById'](_0x388049 + "frites_note")["style"]['display'] = 'none');
+  }
+
+  function resetTacoForm() {
+
+    document['getElementById']('tacosForm')["reset"](), [...meatCheckboxes, ...sauceCheckboxes, ...garnishCheckboxes]["forEach"](_0x4853ba => {
+
+      _0x4853ba["checked"] = !0x1, _0x4853ba["disabled"] = !0x1;
+    });
+  }
+
+  function refreshTacoListUI() {
+
+    0x0 === $("#products-list")["children"]()["length"] ? ($('#product-messages')["html"]("<p class=\"fst-italic\">Veuillez commencer par choisir la taille de vos tacos.</p>"), $("div:contains(\"Tacos dans votre panier\")")['remove']()) : $("#product-messages")["html"]('<div\x20class=\x22bg-danger\x20rounded\x20text-light\x20p-2\x22\x20role=\x22alert\x22><i\x20class=\x22fa-solid\x20fa-chevron-down\x22></i>\x20Tacos\x20dans\x20votre\x20panier</div>'), $("#products-list .card")["each"](function(_0x159822) {
+
+      $(this)["attr"]('id', 'tacos-' + _0x159822), $(this)['attr']("data-index", _0x159822), $(this)["find"](".delete-tacos")["attr"]("data-index", _0x159822);
+    });
+  }
+
+  function loadExistingTacos() {
+
+    var _0x239238 = getCsrfToken();
+    $["ajax"]({
+      'type': "POST",
+      'url': "ajax/owt.php",
+      'headers': {
+        'X-CSRF-Token': _0x239238
+      },
+      'data': {
+        'loadProducts': !0x0
+      },
+      'success': function(_0x3e6ff8) {
+
+        $("#products-list")['html'](_0x3e6ff8), refreshTacoListUI(), refreshCartSummary();
+      },
+      'error': function() {
+
+        location["reload"]();
+      }
+    });
+  }
+  document["addEventListener"]("DOMContentLoaded", function() {
+
+    document["getElementById"]("orderAccordion")["addEventListener"]("click", function(_0x2201a4) {
+      const _0xd0620c = _0x2201a4["target"]["closest"]('.edit-tacos');
+      if (_0xd0620c) {
+        _0x2201a4["preventDefault"]();
+        const _0x3ea2d6 = _0xd0620c["getAttribute"]('data-index'),
+          _0x290c87 = getCsrfToken();
+        document["getElementById"]('editIndex')["value"] = _0x3ea2d6, fetch("ajax/gtd.php", {
+          'method': "POST",
+          'headers': {
+            'X-CSRF-Token': _0x290c87,
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          'body': "index=" + _0x3ea2d6
+        })["then"](_0x49574f => {
+
+          if (!_0x49574f['ok']) throw 0x193 === _0x49574f["status"] && console["log"]("GTD REFRESH"), new Error("GTD Network response was not ok");
+          return _0x49574f["json"]();
+        })["then"](_0x32a4f1 => {
+
+          if ("success" === _0x32a4f1["status"]) {
+            const {
+              taille: _0x17960c,
+              viande: _0xf20883,
+              garniture: _0x5a3a4d,
+              sauce: _0x128092,
+              tacosNote: _0x49431e
+            } = _0x32a4f1["data"];
+            console["log"]('Loaded\x20tacos\x20data:', _0x32a4f1["data"]), console["log"]("Viande data:", _0xf20883), document['getElementById']("editSelectProduct")['value'] = _0x17960c, document['getElementById']("editTaille")['value'] = _0x17960c, document["getElementById"]("editTacosNote")["value"] = _0x49431e, document["querySelectorAll"]("#tacosEditForm input[type=\"checkbox\"]")['forEach'](_0x5342e4 => {
+
+                _0x5342e4["checked"] = !0x1;
+              }),
+              function(_0x5240e1, _0x2c8c27, _0xd03c5c, _0x3f59da) {
+
+                document['querySelectorAll']("#tacosEditForm input[type=\"checkbox\"]")["forEach"](_0x4d1b11 => {
+
+                  _0x4d1b11['checked'] = !0x1, _0x4d1b11["disabled"] = !0x1;
+                }), document["querySelectorAll"]("#tacosEditForm .meat-quantity-control")["forEach"](_0x21eefc => {
+
+                  _0x21eefc['classList']["add"]("d-none");
+                  const _0x4038c2 = _0x21eefc["querySelector"]('.meat-quantity-input');
+                  _0x4038c2 && (_0x4038c2["value"] = 0x1, _0x4038c2["disabled"] = !0x0);
+                });
+                let _0x54deb5 = 0x1;
+                switch (_0x3f59da) {
+                  case "tacos_L":
+                    _0x54deb5 = 0x1;
+                    break;
+                  case "tacos_L_mixte":
+                  case "tacos_XL":
+                    _0x54deb5 = 0x3;
+                    break;
+                  case 'tacos_XXL':
+                    _0x54deb5 = 0x4;
+                    break;
+                  case "tacos_GIGA":
+                    _0x54deb5 = 0x5;
+                }
+                _0x5240e1["forEach"](_0xe764fa => {
+                  const _0x2af82f = document["querySelector"]('#tacosEditForm\x20input[name=\x22viande[]\x22][value=\x22' + _0xe764fa["slug"] + '\x22]');
+                  if (_0x2af82f && (_0x2af82f["checked"] = !0x0, _0x54deb5 > 0x1)) {
+                    const _0x1b776e = _0x2af82f["closest"](".meat-selection-row");
+                    if (_0x1b776e) {
+                      const _0x568555 = _0x1b776e['querySelector'](".meat-quantity-control"),
+                        _0x389096 = _0x1b776e['querySelector'](".meat-quantity-input");
+                      _0x568555 && _0x389096 && (_0x568555["classList"]['remove']("d-none"), _0x389096["value"] = _0xe764fa["quantity"] || 0x1, _0x389096["disabled"] = !0x1);
+                    }
+                  }
+                }), _0x2c8c27["forEach"](_0x122bf2 => {
+                  const _0x49b28c = document['querySelector']("#tacosEditForm input[name=\"garniture[]\"][value=\"" + _0x122bf2["slug"] + '\x22]');
+                  _0x49b28c && (_0x49b28c["checked"] = !0x0);
+                }), _0xd03c5c["forEach"](_0x4de63d => {
+                  const _0x2f3350 = document["querySelector"]('#tacosEditForm\x20input[name=\x22sauce[]\x22][value=\x22' + _0x4de63d["slug"] + '\x22]');
+                  _0x2f3350 && (_0x2f3350["checked"] = !0x0);
+                }), applyEditSelectionLimits(_0x3f59da);
+              }(_0xf20883, _0x5a3a4d, _0x128092, _0x17960c), new bootstrap[("Modal")](document['getElementById']("tacosEditModal"))['show']();
+          } else console['error']("Failed to fetch tacos details:", _0x32a4f1["message"]), console["log"]("Connection error. Please refresh the page.");
+        })['catch'](_0x452342 => console["error"]('Error:', _0x452342));
+      }
+    });
+  }), document["addEventListener"]("DOMContentLoaded", function() {
+
+    document['getElementById']('tacosEditForm')["addEventListener"]('submit', function(_0x3eff30) {
+
+      _0x3eff30['preventDefault']();
+      const _0x2d852e = document["getElementById"]("editSelectProduct")['value'],
+        _0x58a803 = document["querySelectorAll"]("#tacosEditForm input[name=\"viande[]\"]:checked"),
+        _0x414cb3 = document["querySelectorAll"]("#tacosEditForm input[name=\"sauce[]\"]:checked"),
+        _0x1cb967 = document["querySelectorAll"]("#tacosEditForm input[name=\"garniture[]\"]:checked");
+      if (0x0 === _0x58a803['length']) return alert("Veuillez s\u00e9lectionner au moins une viande ou cocher \"sans viande\"."), !0x1;
+      if (0x0 === _0x414cb3["length"]) return alert("Veuillez s\u00e9lectionner au moins une sauce ou cocher \"sans sauce\"."), !0x1;
+      if ("tacos_BOWL" !== _0x2d852e && 0x0 === _0x1cb967['length']) return alert('Veuillez\x20sélectionner\x20au\x20moins\x20une\x20garniture\x20ou\x20cocher\x20\x22sans\x20garniture\x22.'), !0x1;
+      var _0x4a37dc = new FormData(this);
+      _0x58a803["forEach"](_0x30fc5d => {
+        const _0x457280 = _0x30fc5d["value"],
+          _0x47bc6e = _0x30fc5d["closest"](".meat-selection-row"),
+          _0x36e57b = _0x47bc6e ? _0x47bc6e['querySelector'](".meat-quantity-input") : null,
+          _0x23c0ee = _0x36e57b && parseInt(_0x36e57b["value"], 0xa) || 0x1;
+        _0x4a37dc["append"]("meat_quantity[" + _0x457280 + ']', _0x23c0ee);
+      });
+      var _0x39757d = getCsrfToken();
+      fetch("ajax/et.php", {
+        'method': 'POST',
+        'headers': {
+          'X-CSRF-Token': _0x39757d
+        },
+        'body': _0x4a37dc
+      })["then"](_0x5815fc => {
+
+        if (!_0x5815fc['ok']) throw new Error("ET Network response was not ok");
+        return _0x5815fc['text']();
+      })["then"](_0x3bc297 => {
+
+        $("#tacosEditModal")["modal"]("hide"), loadExistingTacos(), refreshTacoListUI(), refreshCartSummary();
+      })["catch"](_0x22b10d => console['error']("Error:", _0x22b10d));
+    });
+  }), document['addEventListener']("DOMContentLoaded", function() {
+    const _0xcf6c19 = document['querySelectorAll']("input[name=\"extras\"]"),
+      _0x23bbad = getCsrfToken();
+    fetch("ajax/gse.php", {
+      'method': 'POST',
+      'headers': {
+        'X-CSRF-Token': _0x23bbad
+      }
+    })["then"](_0x2805ec => {
+
+      if (!_0x2805ec['ok']) throw 0x193 === _0x2805ec["status"] && console["log"]("GSE REFRESH"), new Error("GSE Network response was not ok");
+      return _0x2805ec["json"]();
+    })['then'](_0x19a9e6 => {
+
+      Object["values"](_0x19a9e6)["forEach"](_0x26ab4a => {
+        const _0x2be767 = document["getElementById"](_0x26ab4a['id']);
+        if (_0x2be767) {
+          _0x2be767["checked"] = !0x0;
+          const _0x9a051c = _0x2be767['closest'](".form-check")["querySelector"](".extras-quantity-control");
+          _0x9a051c['classList']["remove"]("d-none"), _0x9a051c['querySelector'](".quantity-input")["value"] = _0x26ab4a['quantity'];
+          const _0x5e5d65 = document['getElementById']("free_sauce_select_" + _0x26ab4a['id']);
+          if (_0x5e5d65) {
+            if (_0x5e5d65["classList"]['remove']('d-none'), _0x26ab4a['free_sauces'] && Array['isArray'](_0x26ab4a["free_sauces"])) _0x5e5d65["querySelectorAll"]('select')['forEach']((_0x4fa08a, _0x1775c7) => {
+
+              _0x26ab4a['free_sauces'][_0x1775c7] && _0x26ab4a["free_sauces"][_0x1775c7]['id'] && (_0x4fa08a["value"] = _0x26ab4a["free_sauces"][_0x1775c7]['id']);
+            });
+            else {
+              if (_0x26ab4a["free_sauce"] && _0x26ab4a["free_sauce"]['id']) {
+                const _0x595b07 = _0x5e5d65['querySelector']("select");
+                _0x595b07 && (_0x595b07["value"] = _0x26ab4a["free_sauce"]['id']);
+              }
+            }
+          }
+        }
+      });
+    })["catch"](_0x352291 => console["error"]("Error:", _0x352291)), (document['querySelectorAll'](".free-sauces-container")["forEach"](_0x44778f => {
+      const _0x5e329c = _0x44778f['id']["replace"]('free_sauce_select_', ''),
+        _0x566517 = document["getElementById"](_0x5e329c);
+      _0x566517 && _0x566517["checked"] || _0x44778f["classList"]["add"]("d-none");
+    }), _0xcf6c19['forEach'](_0x32e72f => {
+
+      _0x32e72f["addEventListener"]("change", function() {
+        const _0x92e91f = this["closest"](".form-check")["querySelector"]('.extras-quantity-control'),
+          _0x2c9aea = document["getElementById"]("free_sauce_select_" + this['id']);
+        this["checked"] ? (_0x92e91f['classList']["remove"]("d-none"), _0x2c9aea && _0x2c9aea["classList"]['remove']("d-none")) : (_0x92e91f['classList']['add']('d-none'), _0x92e91f['querySelector'](".quantity-input")["value"] = 0x1, _0x2c9aea && (_0x2c9aea["classList"]['add']("d-none"), _0x2c9aea["querySelectorAll"]("select")['forEach'](_0x4ccb4e => {
+
+          _0x4ccb4e["value"] = '';
+        })));
+        const _0x27ded4 = this['checked'],
+          _0x432ccb = _0x27ded4 ? parseInt(_0x92e91f["querySelector"](".quantity-input")["value"], 0xa) : 0x0,
+          _0x3fd826 = this['id'],
+          _0xfc099d = this["getAttribute"]("value"),
+          _0x5731c6 = this["closest"](".form-check")['querySelector'](".extras-info")["textContent"],
+          _0x37c922 = parseFloat(_0x5731c6['replace']("CHF ", '')) || 0.5;
+        ['extra_frites', "extra_nuggets", "extra_falafel", "extra_tenders", 'extra_onion_rings', "extra_pommes_gaufrettes", 'extra_mozarella_sticks', "extra_potatoes", 'extra_gaufrettes']["includes"](_0x3fd826) && _0x2c9aea && _0x27ded4 ? submitExtraSelectionWithSauces(_0x3fd826) : submitExtraSelection(_0x3fd826, _0xfc099d, _0x37c922, _0x432ccb);
+      });
+    }), document["querySelectorAll"]('.free-sauces-container\x20select')["forEach"](_0x3e99db => {
+      _0x3e99db['addEventListener']('change', handleFreeSauceSelectionChange);
+    }), document['querySelectorAll'](".extras-quantity-control .increase, .extras-quantity-control .decrease")["forEach"](_0x3a4393 => {
+
+      _0x3a4393["addEventListener"]("click", function() {
+        const _0x248793 = _0x3a4393["closest"]('.extras-quantity-control')["querySelector"](".quantity-input");
+        let _0x2effa6 = parseInt(_0x248793["value"], 0xa);
+        const _0x10f89d = _0x3a4393["closest"](".form-check")["querySelector"](".extra-checkbox"),
+          _0x156121 = _0x10f89d['id'],
+          _0x58cb9f = _0x10f89d["getAttribute"]("value"),
+          _0x387a66 = _0x10f89d["closest"](".form-check")["querySelector"]('.extras-info')["textContent"],
+          _0x1a403a = parseFloat(_0x387a66["replace"]("CHF ", '')) || 0.5;
+        _0x3a4393["classList"]["contains"]('increase') ? _0x2effa6++ : _0x2effa6 > 0x1 && _0x2effa6--, _0x248793["value"] = _0x2effa6, ["extra_frites", "extra_nuggets", "extra_falafel", 'extra_tenders', "extra_onion_rings", "extra_pommes_gaufrettes", "extra_mozarella_sticks", "extra_potatoes", "extra_gaufrettes"]["includes"](_0x156121) ? (! function(_0x5d9806, _0x3110b0) {
+          const _0x515c7a = "localhost" === window["location"]["hostname"] || "127.0.0.1" === window["location"]["hostname"];
+          _0x515c7a && console['log']("updateFreeSauceOptions called with:", _0x5d9806, _0x3110b0);
+          const _0x2196cf = document["getElementById"]('free_sauce_select_' + _0x5d9806);
+          if (!_0x2196cf) return void(_0x515c7a && console['log']("No container found for:", 'free_sauce_select_' + _0x5d9806));
+          const _0x51c227 = _0x2196cf["querySelectorAll"]("select"),
+            _0x4fb19f = [];
+          _0x51c227["forEach"](_0x32448c => {
+
+            _0x32448c["value"] && _0x4fb19f["push"](_0x32448c["value"]);
+          }), _0x515c7a && console["log"]("Saved selections:", _0x4fb19f), (_0x2196cf["innerHTML"] = '', _0x515c7a && console["log"]("Creating", _0x3110b0, 'sauce\x20options'));
+          for (let _0x5b4265 = 0x1; _0x5b4265 <= _0x3110b0; _0x5b4265++) {
+            const _0x481701 = document["createElement"]("div");
+            _0x481701["className"] = "free-sauce-item d-flex flex-column flex-sm-row align-items-start align-items-sm-center mb-2 mt-1";
+            const _0xa30302 = _0x4fb19f[_0x5b4265 - 0x1] || '';
+            let _0x5aabd1 = "<option value=\"\" disabled>Choisissez votre sauce offerte ici.</option>";
+            window["availableSauces"] && Array["isArray"](window['availableSauces']) && (_0x5aabd1 = '<option\x20value=\x22\x22\x20disabled\x20' + (_0xa30302 ? '' : "selected") + ">Choisissez votre sauce offerte ici.</option>", window["availableSauces"]["forEach"](_0x106aa2 => {
+              const _0x355b7b = _0xa30302 === _0x106aa2['id'] ? "selected" : '';
+              _0x5aabd1 += "<option value=\"" + _0x106aa2['id'] + '\x22\x20' + _0x355b7b + '>' + _0x106aa2["name"] + '</option>';
+            })), _0x481701["innerHTML"] = "\n      <i class=\"fa-solid fa-angles-up\" style=\"font-size: 22px; margin-right: 8px; color:#dc3545\"></i>\n      <span class=\"text-danger me-2\">" + _0x5b4265 + ".</span>\n      <select class=\"form-control text-danger form-select-sm\" name=\"free_sauce_" + _0x5d9806 + "[]\" data-item-index=\"" + _0x5b4265 + '\x22>\x0a\x20\x20\x20\x20\x20\x20\x20\x20' + _0x5aabd1 + "\n      </select>\n    ", _0x2196cf["appendChild"](_0x481701);
+          }
+          _0x515c7a && console["log"]("Created", _0x3110b0, "sauce options for", _0x5d9806), ! function(_0x40d02c) {
+            const _0x2035d7 = document["querySelectorAll"]("#free_sauce_select_" + _0x40d02c + " select");
+            _0x2035d7["forEach"](_0x28c3ee => {
+
+              _0x28c3ee["removeEventListener"]("change", handleFreeSauceSelectionChange), _0x28c3ee["addEventListener"]("change", handleFreeSauceSelectionChange);
+            });
+          }(_0x5d9806);
+        }(_0x156121, _0x2effa6), submitExtraSelectionWithSauces(_0x156121)) : submitExtraSelection(_0x156121, _0x58cb9f, _0x1a403a, _0x2effa6);
+      });
+    })), document['querySelectorAll'](".free-sauce-checkbox")["forEach"](_0x85f34 => {
+
+      _0x85f34["addEventListener"]("change", function() {
+        const _0x5305c1 = document['getElementById']("free_sauce_" + this['id']);
+        this["checked"] ? _0x5305c1["classList"]["remove"]("d-none") : _0x5305c1["classList"]['add']("d-none"), _0x5305c1["querySelector"]('select')["addEventListener"]("change", function() {
+
+          submitExtraSelection(this["value"], this['options'][this["selectedIndex"]]["text"], 0x0, 0x1);
+        });
+      });
+    });
+  }), document['addEventListener']('DOMContentLoaded', function() {
+    const _0x4fd6ed = document["querySelectorAll"]("input[name=\"boissons\"]");
+
+    function submitDrinkSelection(_0x8e5a5f, _0x144cf6, _0x524d46, _0x2be603) {
+
+      var _0x3ae88d = getCsrfToken();
+      const _0x268b0a = {
+        'id': _0x8e5a5f,
+        'name': _0x144cf6,
+        'price': _0x524d46,
+        'quantity': _0x2be603
+      };
+      fetch('ajax/ubs.php', {
+        'method': 'POST',
+        'headers': {
+          'X-CSRF-Token': _0x3ae88d
+        },
+        'body': JSON["stringify"](_0x268b0a)
+      })["then"](_0x2bf3c2 => _0x2bf3c2["json"]())['then'](_0x23a90d => {
+        refreshCartSummary();
+      })["catch"](_0x4071c8 => console["error"]("Error:", _0x4071c8));
+    }
+    const _0x1f1d15 = getCsrfToken();
+    fetch("ajax/gsb.php", {
+      'method': "POST",
+      'headers': {
+        'X-CSRF-Token': _0x1f1d15
+      }
+    })["then"](_0x33075f => {
+
+      if (!_0x33075f['ok']) throw 0x193 === _0x33075f["status"] && console["log"]('GSB\x20REFRESH'), new Error('GSB\x20Network\x20response\x20was\x20not\x20ok');
+      return _0x33075f["json"]();
+    })["then"](_0x4e565b => {
+
+      Object["values"](_0x4e565b)['forEach'](_0x5919f4 => {
+        const _0x2dd92a = document["getElementById"](_0x5919f4['id']);
+        if (_0x2dd92a) {
+          _0x2dd92a["checked"] = !0x0;
+          const _0x215f72 = _0x2dd92a['closest'](".form-check")['querySelector']('.boisson-quantity-control');
+          _0x215f72["classList"]["remove"]("d-none"), _0x215f72["querySelector"](".quantity-input")['value'] = _0x5919f4["quantity"];
+        }
+      });
+    })['catch'](_0x44a586 => console["error"]("Error:", _0x44a586)), _0x4fd6ed['forEach'](_0x1e039e => {
+
+      _0x1e039e["addEventListener"]('change', function() {
+        const _0x42e4dc = this["closest"](".form-check")["querySelector"]('.boisson-quantity-control');
+        this['checked'] ? _0x42e4dc["classList"]["remove"]("d-none") : (_0x42e4dc["classList"]["add"]("d-none"), _0x42e4dc["querySelector"]('.quantity-input')["value"] = 0x1);
+        const _0x236c43 = this["checked"] ? parseInt(_0x42e4dc["querySelector"](".quantity-input")["value"], 0xa) : 0x0,
+          _0x437885 = this['id'],
+          _0x217804 = this["getAttribute"]('value'),
+          _0x49ee6c = this['closest']('.form-check')['querySelector'](".boissons-info")["textContent"];
+        submitDrinkSelection(_0x437885, _0x217804, parseFloat(_0x49ee6c["replace"]("CHF ", '')) || 0.5, _0x236c43);
+      });
+    }), document["querySelectorAll"]('.boisson-quantity-control\x20.increase,\x20.boisson-quantity-control\x20.decrease')["forEach"](_0x302272 => {
+
+      _0x302272["addEventListener"]("click", function() {
+        const _0xde349e = this["closest"]('.boisson-quantity-control')["querySelector"](".quantity-input");
+        let _0x2e2cb8 = parseInt(_0xde349e["value"], 0xa);
+        _0x2e2cb8 += this['classList']["contains"]("increase") ? 0x1 : _0x2e2cb8 > 0x1 ? -0x1 : 0x0, _0xde349e["value"] = _0x2e2cb8;
+        const _0x208b15 = this['closest'](".boisson-quantity-control")["getAttribute"]("data-boisson-id"),
+          _0x3b3a8b = document["getElementById"](_0x208b15),
+          _0x326289 = _0x3b3a8b['getAttribute']("value"),
+          _0x228110 = _0x3b3a8b["closest"](".form-check")["querySelector"](".boissons-info")["textContent"];
+        submitDrinkSelection(_0x208b15, _0x326289, parseFloat(_0x228110["replace"]("CHF ", '')) || 0.5, _0x2e2cb8);
+      });
+    });
+  }), document["addEventListener"]('DOMContentLoaded', function() {
+    const _0x485491 = document['querySelectorAll']("input[name=\"desserts\"]");
+
+    function submitDessertSelection(_0x4a6d01, _0x5b4df2, _0x44a2f8, _0x1c3334) {
+
+      var _0x43f072 = getCsrfToken();
+      const _0xf28ac5 = {
+        'id': _0x4a6d01,
+        'name': _0x5b4df2,
+        'price': _0x44a2f8,
+        'quantity': _0x1c3334
+      };
+      fetch("ajax/uds.php", {
+        'method': "POST",
+        'headers': {
+          'X-CSRF-Token': _0x43f072
+        },
+        'body': JSON['stringify'](_0xf28ac5)
+      })['then'](_0x5addaa => _0x5addaa["json"]())['then'](_0x3a02a0 => {
+        refreshCartSummary();
+      })["catch"](_0x130ccf => console["error"]("Error:", _0x130ccf));
+    }
+    const _0x119505 = getCsrfToken();
+    fetch("ajax/gsd.php", {
+      'method': "POST",
+      'headers': {
+        'X-CSRF-Token': _0x119505
+      }
+    })['then'](_0x3f0fc9 => {
+
+      if (!_0x3f0fc9['ok']) throw 0x193 === _0x3f0fc9["status"] && console["log"]('GSD\x20REFRESH'), new Error("GSD Network response was not ok");
+      return _0x3f0fc9["json"]();
+    })["then"](_0x10058d => {
+
+      Object['values'](_0x10058d)["forEach"](_0x39a3c6 => {
+        const _0x55c3cf = document["getElementById"](_0x39a3c6['id']);
+        if (_0x55c3cf) {
+          _0x55c3cf["checked"] = !0x0;
+          const _0x4668a6 = _0x55c3cf["closest"]('.form-check')["querySelector"](".dessert-quantity-control");
+          _0x4668a6['classList']["remove"]('d-none'), _0x4668a6["querySelector"]('.quantity-input')["value"] = _0x39a3c6["quantity"];
+        }
+      });
+    })["catch"](_0x362336 => console["error"]('Error:', _0x362336)), _0x485491["forEach"](_0x16f575 => {
+
+      _0x16f575["addEventListener"]("change", function() {
+        const _0x454838 = this["closest"](".form-check")["querySelector"](".dessert-quantity-control");
+        this["checked"] ? _0x454838['classList']["remove"]("d-none") : (_0x454838["classList"]["add"]("d-none"), _0x454838["querySelector"](".quantity-input")['value'] = 0x1);
+        const _0x1b071e = this["checked"] ? parseInt(_0x454838["querySelector"]('.quantity-input')["value"], 0xa) : 0x0,
+          _0x437937 = this['id'],
+          _0x1d6814 = this["getAttribute"]('value'),
+          _0x25409d = this["closest"]('.form-check')["querySelector"](".desserts-info")["textContent"];
+        submitDessertSelection(_0x437937, _0x1d6814, parseFloat(_0x25409d["replace"]('CHF\x20', '')) || 0.5, _0x1b071e);
+      });
+    }), document['querySelectorAll'](".dessert-quantity-control .increase, .dessert-quantity-control .decrease")['forEach'](_0x2db0de => {
+
+      _0x2db0de["addEventListener"]("click", function() {
+        const _0x5e666d = this['closest'](".dessert-quantity-control")["querySelector"](".quantity-input");
+        let _0x424dba = parseInt(_0x5e666d["value"], 0xa);
+        _0x424dba += this["classList"]['contains']('increase') ? 0x1 : _0x424dba > 0x1 ? -0x1 : 0x0, _0x5e666d['value'] = _0x424dba;
+        const _0x2dafbb = this['closest'](".dessert-quantity-control")["getAttribute"]("data-dessert-id"),
+          _0x2f943e = document["getElementById"](_0x2dafbb),
+          _0x25ff2f = _0x2f943e["getAttribute"]("value"),
+          _0x262a57 = _0x2f943e["closest"](".form-check")['querySelector'](".desserts-info")['textContent'];
+        submitDessertSelection(_0x2dafbb, _0x25ff2f, parseFloat(_0x262a57['replace']('CHF\x20', '')) || 0.5, _0x424dba);
+      });
+    });
+  }), document["addEventListener"]('DOMContentLoaded', refreshCategoryBadges), document['addEventListener']("DOMContentLoaded", refreshCartSummary), document["addEventListener"]("DOMContentLoaded", function() {
+
+    document["getElementById"]("orderModal")["addEventListener"]("show.bs.modal", function(_0x1ae7af) {
+
+      var _0x486822 = getCsrfToken();
+      fetch("ajax/os.php", {
+        'method': 'POST',
+        'headers': {
+          'Content-Type': "application/x-www-form-urlencoded"
+        },
+        'body': "csrf_token=" + encodeURIComponent(_0x486822)
+      })["then"](_0x19dbb3 => {
+
+        if (!_0x19dbb3['ok']) throw 0x193 === _0x19dbb3['status'] && console['log']("OS REFRESH"), new Error("Network response was not ok");
+        return _0x19dbb3["text"]();
+      })["then"](_0x127da7 => {
+        document['querySelector']('#orderModal\x20.order-summary')['innerHTML'] = _0x127da7;
+      })["catch"](_0x3be85e => console["error"]('Error\x20loading\x20the\x20order\x20summary:', _0x3be85e));
+    });
+  }), document["getElementById"]("selectProduct")['addEventListener']('change', function() {
+
+    toggleTacoOptionsBySize(this["value"], "add_");
+  }), document["getElementById"]("tacosEditModal")['addEventListener']("show.bs.modal", function() {
+
+    toggleTacoOptionsBySize(document["getElementById"]("editTaille")['value'], "edit_");
+  }), document["addEventListener"]("DOMContentLoaded", function() {
+
+    document['querySelector']("#confirmMinOrderModal .btn-danger")["addEventListener"]("click", function() {
+
+      new bootstrap['Modal'](document["getElementById"]('confirmMinOrderModal'))["hide"](), setTimeout(function() {
+
+        new bootstrap[("Modal")](document["getElementById"]("orderModal"))['show']();
+      }, 0x1f4);
+    });
+  }), document["addEventListener"]("DOMContentLoaded", function() {
+    const _0x69b6ef = document["getElementById"]("selectProduct");
+
+    function setInputsDisabled(_0x663f96, _0x30d55f = !0x0) {
+
+      _0x663f96["forEach"](_0x8270e9 => {
+
+        _0x8270e9["disabled"] = _0x30d55f, _0x30d55f && (_0x8270e9["checked"] = !0x1);
+      });
+    }
+
+    function enforceMeatSelectionLimit(_0x226765) {
+
+      let _0x168391 = [...meatCheckboxes]["filter"](_0x2746b1 => _0x2746b1["checked"])["length"];
+      meatCheckboxes["forEach"](_0x5b8c6f => {
+        _0x5b8c6f['addEventListener']('change', () => {
+
+          _0x168391 = [...meatCheckboxes]["filter"](_0x2e0bc3 => _0x2e0bc3["checked"])["length"], _0x168391 >= _0x226765 ? setInputsDisabled([...meatCheckboxes]["filter"](_0x5b7bc1 => !_0x5b7bc1['checked']), !0x0) : setInputsDisabled(meatCheckboxes, !0x1);
+        });
+      });
+    }
+    meatCheckboxes = document["querySelectorAll"]("input[name=\"viande[]\"]"), sauceCheckboxes = document["querySelectorAll"]("input[name=\"sauce[]\"]"), garnishCheckboxes = document['querySelectorAll']("input[name=\"garniture[]\"]"), _0x69b6ef["addEventListener"]('change', () => {
+
+      [...meatCheckboxes, ...sauceCheckboxes, ...garnishCheckboxes]["forEach"](_0xb20a2e => {
+
+        _0xb20a2e["checked"] = !0x1;
+      });
+      const _0x196dff = _0x69b6ef["value"];
+      switch (setInputsDisabled(meatCheckboxes, !0x1), setInputsDisabled(sauceCheckboxes, !0x1), setInputsDisabled(garnishCheckboxes, !0x1), _0x196dff) {
+        case 'tacos_L':
+          enforceMeatSelectionLimit(0x1);
+          break;
+        case "tacos_BOWL":
+          enforceMeatSelectionLimit(0x2);
+          break;
+        case "tacos_L_mixte":
+        case "tacos_XL":
+          enforceMeatSelectionLimit(0x3);
+          break;
+        case 'tacos_XXL':
+          enforceMeatSelectionLimit(0x4);
+          break;
+        case "tacos_GIGA":
+          enforceMeatSelectionLimit(0x5);
+          break;
+        default:
+          setInputsDisabled(meatCheckboxes, !0x0), setInputsDisabled(sauceCheckboxes, !0x0), setInputsDisabled(garnishCheckboxes, !0x0);
+      }
+      sauceCheckboxes["forEach"](_0x205ffb => {
+
+        _0x205ffb['addEventListener']("change", () => {
+
+          [...sauceCheckboxes]["filter"](_0x3c6da6 => _0x3c6da6["checked"])["length"] >= 0x3 ? setInputsDisabled([...sauceCheckboxes]["filter"](_0x5e9e1c => !_0x5e9e1c["checked"]), !0x0) : setInputsDisabled(sauceCheckboxes, !0x1);
+        });
+      });
+    }), (document["querySelectorAll"](".add-tacos-button")['forEach'](_0x5be73c => {
+
+      _0x5be73c["addEventListener"]("click", function(_0x42e613) {
+
+        _0x42e613["preventDefault"](), !async function(_0x343318) {
+
+          new bootstrap[("Modal")](document["getElementById"]("tacosAddModal"), {
+            'keyboard': !0x1
+          })["show"](), document["getElementById"]("selectProduct")["value"] = _0x343318, _0x69b6ef["dispatchEvent"](new Event('change', {
+            'bubbles': !0x0,
+            'cancelable': !0x0
+          })), await fetchStockAvailability(), applyStockAvailability();
+        }(this['getAttribute']("data-tacos-type"));
+      });
+    }), setInputsDisabled(meatCheckboxes), setInputsDisabled(sauceCheckboxes), setInputsDisabled(garnishCheckboxes), $("#tacosAddModal")['on']("hidden.bs.modal", function() {
+
+      resetTacoForm(), _0x69b6ef["value"] = 'null', setInputsDisabled(meatCheckboxes, !0x0), setInputsDisabled(sauceCheckboxes, !0x0), setInputsDisabled(garnishCheckboxes, !0x0);
+    }));
+  }), $('#tacosForm')["submit"](function(_0x5d76a5) {
+
+    _0x5d76a5["preventDefault"]();
+    const _0x2b8cf5 = document["getElementById"]("selectProduct")["value"],
+      _0x2df9c0 = document["querySelectorAll"]("input[name=\"viande[]\"]:checked"),
+      _0x436197 = document["querySelectorAll"]("input[name=\"sauce[]\"]:checked"),
+      _0x2dcc7d = document["querySelectorAll"]("input[name=\"garniture[]\"]:checked");
+    document["querySelector"]("input[name=\"viande[]\"][value=\"sans\"]:checked"), document["querySelector"]('input[name=\x22sauce[]\x22][value=\x22sans\x22]:checked'), document["querySelector"]("input[name=\"garniture[]\"][value=\"sans\"]:checked");
+    if (0x0 === _0x2df9c0["length"]) return alert("Veuillez s\u00e9lectionner au moins une viande ou cocher \"sans viande\"."), !0x1;
+    if (0x0 === _0x436197["length"]) return alert("Veuillez s\u00e9lectionner au moins une sauce ou cocher \"sans sauce\"."), !0x1;
+    if ("tacos_BOWL" !== _0x2b8cf5 && 0x0 === _0x2dcc7d["length"]) return alert('Veuillez\x20sélectionner\x20au\x20moins\x20une\x20garniture\x20ou\x20cocher\x20\x22sans\x20garniture\x22.'), !0x1;
+    var _0x22bd28 = getCsrfToken();
+    const _0x83e35c = {};
+    _0x2df9c0["forEach"](_0x34e18d => {
+      const _0x281d57 = _0x34e18d['value'],
+        _0x16ef78 = _0x34e18d['closest'](".meat-selection-row"),
+        _0x402287 = _0x16ef78 ? _0x16ef78["querySelector"](".meat-quantity-input") : null,
+        _0x1abbe5 = _0x402287 && parseInt(_0x402287["value"], 0xa) || 0x1;
+      _0x83e35c[_0x281d57] = _0x1abbe5;
+    });
+    let _0xe34811 = $(this)['serialize']();
+    Object["keys"](_0x83e35c)["forEach"](_0x2cefc4 => {
+
+      _0xe34811 += "&meat_quantity[" + _0x2cefc4 + ']=' + _0x83e35c[_0x2cefc4];
+    }), $["ajax"]({
+      'type': 'POST',
+      'url': "ajax/owt.php",
+      'headers': {
+        'X-CSRF-Token': _0x22bd28
+      },
+      'data': _0xe34811,
+      'success': function(_0x3a0047) {
+
+        $("#products-list")["append"](_0x3a0047), $("#product-messages")['empty'](), loadExistingTacos(), refreshTacoListUI(), refreshCartSummary();
+      },
+      'error': function() {
+        alert('Error\x20on\x20submit.\x20Please\x20try\x20again.');
+      }
+    }), $("#tacosAddModal")["modal"]('hide'), resetTacoForm();
+  }), $(document)['on']("click", ".delete-tacos", function(_0x314073) {
+
+    _0x314073["preventDefault"]();
+    var _0x1ea80e = $(this)['attr']('data-index');
+    if (confirm("\u00cates-vous s\u00fbr de vouloir supprimer ce produit\u00a0?")) {
+      var _0x49e47e = getCsrfToken();
+      $["ajax"]({
+        'url': "ajax/dt.php",
+        'headers': {
+          'X-CSRF-Token': _0x49e47e
+        },
+        'type': "POST",
+        'data': {
+          'index': _0x1ea80e
+        },
+        'success': function(_0x20d692) {
+
+          $('#tacos-' + _0x1ea80e)["remove"](), refreshTacoListUI(), refreshCartSummary();
+        },
+        'error': function() {
+          alert('Error\x20on\x20delete.\x20Please\x20try\x20again.');
+        }
+      });
+    }
+  }), $(document)["ready"](function() {
+    loadExistingTacos();
+  }), document["getElementById"]("orderForm")['addEventListener']("submit", function(_0x3dad45) {
+
+    _0x3dad45["preventDefault"]();
+    const _0x4f1851 = document["getElementById"]('finalizeButton'),
+      _0x40ee4f = _0x4f1851 ? _0x4f1851['innerHTML'] : 'Finaliser\x20la\x20commande';
+    if (document["getElementById"]("phone")['value'] !== document["getElementById"]("confirmPhone")['value']) return void alert("Les num\u00e9ros de t\u00e9l\u00e9phone ne correspondent pas, veuillez v\u00e9rifier !");
+    _0x4f1851 && (_0x4f1851['disabled'] = !0x0, _0x4f1851["innerHTML"] = "<span class=\"spinner-border spinner-border-sm me-2\"></span>Traitement en cours...", _0x4f1851["classList"]["add"]("disabled"));
+    const _0x32f5c8 = Date["now"]() + '_' + Math['random']()['toString'](0x24)['substr'](0x2, 0x9),
+      _0x312021 = getCsrfToken();
+    var _0x5cc408 = new FormData(this);
+    _0x5cc408["append"]("transaction_id", _0x32f5c8), fetch("ajax/RocknRoll.php", {
+      'method': "POST",
+      'headers': {
+        'X-CSRF-Token': _0x312021
+      },
+      'body': _0x5cc408
+    })["then"](_0x5bfbb0 => {
+
+      if (!_0x5bfbb0['ok']) {
+        if (0x199 === _0x5bfbb0["status"]) return _0x5bfbb0['json']()["then"](_0x5a1e72 => {
+          throw new Error('DUPLICATE_ORDER');
+        });
+        if (0x193 === _0x5bfbb0["status"]) return _0x5bfbb0["text"]()['then'](_0x33cc81 => {
+
+          if (_0x33cc81["includes"]('1\x20Order\x20per\x20minute') || _0x33cc81['includes']("Maximum")) throw new Error("RATE_LIMIT");
+          throw new Error("FORBIDDEN");
+        });
+        throw new Error('RocknRoll\x20Network\x20response\x20was\x20not\x20ok');
+      }
+      return _0x5bfbb0["json"]();
+    })['then'](_0x28660b => {
+
+      if (!_0x28660b) throw console["error"]("Unexpected response structure:", _0x28660b), new Error("Error during order processing");
+      {
+        _0x4f1851 && (_0x4f1851["classList"]["remove"]("btn-danger"), _0x4f1851["classList"]["add"]("btn-success"), _0x4f1851['innerHTML'] = "<i class=\"fas fa-check me-2\"></i>Commande confirm\u00e9e!"), localStorage["removeItem"]("accordionState"), document["querySelectorAll"](".collapse.show")["forEach"](_0x35f863 => {
+
+          new bootstrap[("Collapse")](_0x35f863, {
+            'toggle': !0x1
+          })["hide"]();
+        });
+        var _0x144cb2 = localStorage['getItem']('order_stories');
+        (_0x144cb2 = _0x144cb2 ? JSON["parse"](_0x144cb2) : [])['push'](_0x28660b), localStorage["setItem"]('order_stories', JSON["stringify"](_0x144cb2));
+        let _0x349c4d = '';
+        "livraison" === new URLSearchParams(window["location"]["search"])["get"]("content") ? _0x349c4d = '<div\x20class=\x22d-flex\x20justify-content-center\x20align-items-center\x22\x20style=\x22height:\x20100px;\x22><i\x20class=\x27fa\x20fa-check-circle\x27\x20style=\x27color:\x20green;\x20font-size:\x20100px;\x27></i></div><br\x20/>Votre\x20commande\x20a\x20été\x20reçue\x20et\x20sera\x20préparée.<br>Restez\x20joignable\x20s\x27il\x20vous\x20plaît.<br>Celui-ci\x20sera\x20mis\x20à\x20jour\x20lorsque\x20votre\x20commande\x20sera\x20en\x20route.' : "emporter" === new URLSearchParams(window["location"]["search"])["get"]("content") && (_0x349c4d = "<div class=\"d-flex justify-content-center align-items-center\" style=\"height: 100px;\"><i class='fa fa-check-circle' style='color: green; font-size: 100px; margin-right: 15px;'></i>Votre commande a \u00e9t\u00e9 re\u00e7ue et sera pr\u00e9par\u00e9e.</div>"), $("#orderModal")['on']("hidden.bs.modal", function() {
+
+          $('#successModalBody')["html"](_0x349c4d), $("#successModal")['modal']("show");
+        })["modal"]("hide"), $('#successModal')['on']("hidden.bs.modal", function() {
+
+          window["location"]['reload']();
+        }), gtag("event", 'purchase', {
+          'transaction_id': _0x28660b["orderId"],
+          'affiliation': "Website",
+          'value': _0x28660b['OrderData']['price'],
+          'currency': "CHF"
+        });
+      }
+    })["catch"](_0x46a311 => {
+
+      "undefined" != typeof isDevMode && isDevMode && (console["error"]("Error type:", _0x46a311["name"]), console["error"]('Error\x20message:', _0x46a311["message"]), console["error"]('Error\x20stack:', _0x46a311["stack"])), _0x4f1851 && ("DUPLICATE_ORDER" === _0x46a311["message"] ? (_0x4f1851["classList"]['remove']("btn-danger"), _0x4f1851["classList"]["add"]('btn-info'), _0x4f1851["innerHTML"] = "<i class=\"fas fa-info-circle me-2\"></i>Cette commande a d\u00e9j\u00e0 \u00e9t\u00e9 trait\u00e9e", setTimeout(() => {
+
+        _0x4f1851['disabled'] = !0x1, _0x4f1851['classList']['remove']('btn-info', "disabled"), _0x4f1851['classList']["add"]("btn-danger"), _0x4f1851["innerHTML"] = _0x40ee4f;
+      }, 0xbb8)) : "RATE_LIMIT" === _0x46a311["message"] ? (_0x4f1851["classList"]["remove"]('btn-danger'), _0x4f1851["classList"]["add"]("btn-warning"), _0x4f1851["innerHTML"] = '<i\x20class=\x22fas\x20fa-exclamation-triangle\x20me-2\x22></i>Veuillez\x20patienter\x201\x20minute', setTimeout(() => {
+
+        _0x4f1851["disabled"] = !0x1, _0x4f1851["classList"]['remove']('btn-warning', "disabled"), _0x4f1851["classList"]['add']("btn-danger"), _0x4f1851["innerHTML"] = _0x40ee4f;
+      }, 0x1388)) : _0x46a311['message']["includes"]("Network") ? (_0x4f1851["classList"]["add"]("btn-danger"), _0x4f1851['innerHTML'] = "<i class=\"fas fa-wifi me-2\"></i>Erreur de connexion", setTimeout(() => {
+
+        _0x4f1851["disabled"] = !0x1, _0x4f1851["classList"]["remove"]("disabled"), _0x4f1851['innerHTML'] = _0x40ee4f;
+      }, 0xbb8)) : (_0x4f1851["classList"]["add"]('btn-danger'), _0x4f1851['innerHTML'] = "<i class=\"fas fa-times me-2\"></i>Erreur - Veuillez r\u00e9essayer", setTimeout(() => {
+
+        _0x4f1851['disabled'] = !0x1, _0x4f1851["classList"]["remove"]('disabled'), _0x4f1851["innerHTML"] = _0x40ee4f;
+      }, 0xbb8))), "RATE_LIMIT" === _0x46a311["message"] ? alert("Vous avez d\u00e9j\u00e0 pass\u00e9 une commande r\u00e9cemment. Veuillez patienter 1 minute avant de commander \u00e0 nouveau.") : "FORBIDDEN" === _0x46a311["message"] ? alert("Acc\u00e8s refus\u00e9. Veuillez r\u00e9essayer.") : _0x46a311["message"]["includes"]("Network") ? alert("Probl\u00e8me de connexion. V\u00e9rifiez votre connexion internet et r\u00e9essayez.") : alert("Une erreur est survenue lors de la soumission du formulaire. Veuillez r\u00e9essayer.");
+    });
+  }), document["addEventListener"]("DOMContentLoaded", function() {
+    const _0x2080bf = document["getElementById"]("addToHomeText"),
+      _0x12fe61 = document["getElementById"]("bannerLogo"),
+      _0x63a503 = navigator['userAgent']["toLowerCase"]();
+
+    function updateAddToHomePrompt(_0x5b4b93, _0x24442b) {
+      _0x2080bf['textContent'] = _0x5b4b93, _0x12fe61['src'] = _0x24442b;
+    }
+    /iphone|ipad/ ["test"](_0x63a503) ? updateAddToHomePrompt("Appuyez sur l\u2019ic\u00f4ne de partage (en bas au centre) et s\u00e9lectionnez \u00ab Ajouter \u00e0 l\u2019\u00e9cran d\u2019accueil \u00bb.", './images/ios-share.png'): /android/ ['test'](_0x63a503) && updateAddToHomePrompt("Dans le menu du navigateur (en haut \u00e0 droite), s\u00e9lectionnez \u00ab Ajouter \u00e0 l\u2019\u00e9cran d\u2019accueil \u00bb.", "./images/android-share.png");
+  });
+  let maxMeatPortions = 0x1;
+
+  function handleFreeSauceSelectionChange(_0x4587bf) {
+    const _0x535624 = _0x4587bf["target"]["closest"](".free-sauces-container");
+    _0x535624 && submitExtraSelectionWithSauces(_0x535624['id']["replace"]("free_sauce_select_", ''));
+  }
+
+  function submitExtraSelectionWithSauces(_0x49881d) {
+    const _0x6a5a15 = document["getElementById"](_0x49881d),
+      _0x406233 = _0x6a5a15["closest"]('.form-check')["querySelector"](".quantity-input"),
+      _0x51a4cd = parseInt(_0x406233["value"], 0xa),
+      _0x2b41ff = _0x6a5a15["getAttribute"]('value'),
+      _0x378ceb = _0x6a5a15["closest"]('.form-check')["querySelector"](".extras-info")["textContent"],
+      _0x3f0e8f = parseFloat(_0x378ceb["replace"]("CHF ", '')) || 0.5,
+      _0x5a154b = document["querySelectorAll"]("#free_sauce_select_" + _0x49881d + " select"),
+      _0x3a812d = [];
+    _0x5a154b["forEach"](_0x5559ea => {
+
+      if (_0x5559ea["value"]) {
+        const _0x5bc344 = _0x5559ea["options"][_0x5559ea["selectedIndex"]]['text'];
+        _0x3a812d["push"]({
+          'id': _0x5559ea["value"],
+          'name': _0x5bc344,
+          'price': 0x0
+        });
+      }
+    }), submitExtraSelection(_0x49881d, _0x2b41ff, _0x3f0e8f, _0x51a4cd, null, null, _0x3a812d);
+  }
+  document["addEventListener"]("DOMContentLoaded", function() {
+    const _0x460fab = document["getElementById"]("selectProduct"),
+      _0x44c59b = document['querySelectorAll']("input[name=\"viande[]\"]"),
+      _0x147a8f = document["querySelectorAll"]("input[name=\"sauce[]\"]"),
+      _0x4416e6 = document['querySelectorAll']("input[name=\"garniture[]\"]");
+
+    function enforceMeatQuantityLimits() {
+      const _0x32cb0a = [..._0x44c59b]["filter"](_0x23aac3 => _0x23aac3["checked"]);
+      let _0x39dff6 = 0x0;
+      0x1 === maxMeatPortions ? _0x39dff6 = _0x32cb0a["length"] : _0x32cb0a["forEach"](_0x5232bf => {
+        const _0x492872 = _0x5232bf["closest"](".meat-selection-row");
+        if (_0x492872) {
+          const _0x5ecbbb = _0x492872['querySelector'](".meat-quantity-input"),
+            _0x2684e2 = parseInt(_0x5ecbbb?.["value"] || 0x1);
+          _0x39dff6 += _0x2684e2;
+        }
+      }), _0x44c59b["forEach"](_0x47b119 => {
+
+        _0x47b119["checked"] || (_0x47b119["disabled"] = _0x39dff6 >= maxMeatPortions);
+      }), _0x32cb0a["forEach"](_0x134da7 => {
+        const _0x18bce7 = _0x134da7["closest"](".meat-selection-row");
+        if (_0x18bce7) {
+          const _0x2ebe79 = _0x18bce7['querySelector'](".meat-quantity-input");
+          if (_0x2ebe79) {
+            const _0x21b4b0 = parseInt(_0x2ebe79['value']),
+              _0x355d63 = maxMeatPortions - _0x39dff6 + _0x21b4b0;
+            _0x2ebe79["max"] = Math['min'](_0x355d63, 0x5), _0x21b4b0 > _0x2ebe79["max"] && (_0x2ebe79["value"] = _0x2ebe79['max']);
+          }
+        }
+      });
+    }
+    _0x44c59b["forEach"](_0x13e067 => {
+
+      _0x13e067["addEventListener"]("change", function() {
+        const _0x566657 = this['closest']('.meat-selection-row');
+        if (_0x566657) {
+          const _0x4e4244 = _0x566657["querySelector"](".meat-quantity-control");
+          if (_0x4e4244) {
+            if (this["checked"] && maxMeatPortions > 0x1) _0x4e4244["classList"]["remove"]('d-none'), enforceMeatQuantityLimits();
+            else {
+              _0x4e4244["classList"]["add"]("d-none");
+              const _0x802dc2 = _0x4e4244["querySelector"](".meat-quantity-input");
+              _0x802dc2 && (_0x802dc2["value"] = 0x1);
+            }
+          }
+        }
+        enforceMeatQuantityLimits();
+      });
+    }), document["querySelectorAll"](".increase-meat")['forEach'](_0x2f595b => {
+
+      _0x2f595b["addEventListener"]('click', function() {
+        const _0x1d40b5 = this["parentElement"]["querySelector"](".meat-quantity-input");
+        if (_0x1d40b5) {
+          const _0x309dc3 = parseInt(_0x1d40b5["value"]) || 0x1;
+          _0x309dc3 < (parseInt(_0x1d40b5["max"]) || maxMeatPortions) && (_0x1d40b5["value"] = _0x309dc3 + 0x1, enforceMeatQuantityLimits());
+        }
+      });
+    }), document["querySelectorAll"](".decrease-meat")["forEach"](_0x154400 => {
+
+      _0x154400["addEventListener"]("click", function() {
+        const _0x894774 = this["parentElement"]["querySelector"](".meat-quantity-input");
+        if (_0x894774) {
+          const _0xd88152 = parseInt(_0x894774['value']) || 0x1;
+          _0xd88152 > 0x1 && (_0x894774["value"] = _0xd88152 - 0x1, enforceMeatQuantityLimits());
+        }
+      });
+    }), _0x147a8f['forEach'](_0x2db7e5 => {
+
+      _0x2db7e5["addEventListener"]("change", function() {
+
+        [..._0x147a8f]['filter'](_0x427e0c => _0x427e0c['checked'])["length"] >= 0x3 ? [..._0x147a8f]["filter"](_0x3dc028 => !_0x3dc028["checked"])["forEach"](_0x2b6583 => _0x2b6583["disabled"] = !0x0) : _0x147a8f["forEach"](_0x356c36 => {
+
+          _0x356c36["checked"] || (_0x356c36["disabled"] = !0x1);
+        });
+      });
+    }), _0x460fab && (_0x460fab["addEventListener"]('change', function() {
+      const _0x3d76d2 = this["value"];
+      switch ([..._0x44c59b, ..._0x147a8f, ..._0x4416e6]["forEach"](_0x1f1dd1 => {
+
+          _0x1f1dd1["checked"] = !0x1, _0x1f1dd1["disabled"] = !0x1;
+        }), document["querySelectorAll"](".meat-quantity-control")["forEach"](_0x18e315 => {
+
+          _0x18e315["classList"]['add']("d-none");
+          const _0x473994 = _0x18e315["querySelector"]('.meat-quantity-input');
+          _0x473994 && (_0x473994["value"] = 0x1);
+        }), _0x3d76d2) {
+        case "tacos_L":
+          maxMeatPortions = 0x1;
+          break;
+        case "tacos_BOWL":
+          maxMeatPortions = 0x2;
+          break;
+        case "tacos_L_mixte":
+        case 'tacos_XL':
+          maxMeatPortions = 0x3;
+          break;
+        case 'tacos_XXL':
+          maxMeatPortions = 0x4;
+          break;
+        case "tacos_GIGA":
+          maxMeatPortions = 0x5;
+          break;
+        default:
+          return maxMeatPortions = 0x0, void[..._0x44c59b, ..._0x147a8f, ..._0x4416e6]["forEach"](_0x4ddade => _0x4ddade["disabled"] = !0x0);
+      } [..._0x44c59b, ..._0x147a8f, ..._0x4416e6]["forEach"](_0x18014a => _0x18014a["disabled"] = !0x1);
+    }), [..._0x44c59b, ..._0x147a8f, ..._0x4416e6]["forEach"](_0x3317b1 => _0x3317b1['disabled'] = !0x0)), $("#tacosAddModal")['on']("hidden.bs.modal", function() {
+
+      _0x460fab && (_0x460fab["value"] = "null", [..._0x44c59b, ..._0x147a8f, ..._0x4416e6]["forEach"](_0x316bb9 => {
+
+        _0x316bb9["checked"] = !0x1, _0x316bb9["disabled"] = !0x0;
+      }), document['querySelectorAll'](".meat-quantity-control")['forEach'](_0x2bf7c7 => {
+
+        _0x2bf7c7["classList"]["add"]("d-none");
+        const _0xd33737 = _0x2bf7c7['querySelector']('.meat-quantity-input');
+        _0xd33737 && (_0xd33737["value"] = 0x1);
+      }), maxMeatPortions = 0x0);
+    });
+  }), document['addEventListener']("DOMContentLoaded", function() {
+
+    document["querySelectorAll"]("#tacosEditForm input[name=\"viande[]\"]")['forEach'](_0x41f40e => {
+
+      _0x41f40e["addEventListener"]("change", function() {
+        const _0x2d7bf8 = this["closest"](".meat-selection-row");
+        if (_0x2d7bf8) {
+          const _0x4ba95a = _0x2d7bf8["querySelector"]('.meat-quantity-control');
+          if (_0x4ba95a) {
+            let _0x3e63b2 = 0x1;
+            switch (document["getElementById"]("editSelectProduct")["value"]) {
+              case "tacos_L":
+                _0x3e63b2 = 0x1;
+                break;
+              case "tacos_L_mixte":
+              case "tacos_XL":
+                _0x3e63b2 = 0x3;
+                break;
+              case "tacos_XXL":
+                _0x3e63b2 = 0x4;
+                break;
+              case "tacos_GIGA":
+                _0x3e63b2 = 0x5;
+            }
+            const _0x36a9fc = _0x4ba95a["querySelector"]('.meat-quantity-input');
+            this["checked"] && _0x3e63b2 > 0x1 ? (_0x4ba95a["classList"]["remove"]("d-none"), _0x36a9fc && (_0x36a9fc["disabled"] = !0x1)) : (_0x4ba95a["classList"]["add"]("d-none"), _0x36a9fc && (_0x36a9fc["value"] = 0x1, _0x36a9fc["disabled"] = !0x0));
+          }
+        }
+      });
+    }), document["querySelectorAll"]("#tacosEditForm .increase-meat")['forEach'](_0x4ed2c5 => {
+
+      _0x4ed2c5["addEventListener"]("click", function() {
+        const _0x38db9b = this["parentElement"]['querySelector'](".meat-quantity-input");
+        if (_0x38db9b) {
+          const _0x117e57 = parseInt(_0x38db9b["value"]) || 0x1;
+          _0x117e57 < (parseInt(_0x38db9b["max"]) || 0x5) && (_0x38db9b["value"] = _0x117e57 + 0x1);
+        }
+      });
+    }), document["querySelectorAll"]("#tacosEditForm .decrease-meat")["forEach"](_0x41a64c => {
+
+      _0x41a64c["addEventListener"]("click", function() {
+        const _0x415698 = this['parentElement']['querySelector'](".meat-quantity-input");
+        if (_0x415698) {
+          const _0x44945f = parseInt(_0x415698["value"]) || 0x1;
+          _0x44945f > 0x1 && (_0x415698["value"] = _0x44945f - 0x1);
+        }
+      });
+    });
+  }), document["addEventListener"]('DOMContentLoaded', function() {
+
+    try {
+      if (!window["location"]["search"]['includes']("content=livraison")) return;
+      const _0x3e72d8 = document['querySelector']('select[name=\x22requestedFor\x22]'),
+        _0x44e783 = document["getElementById"]("deliveryDemandWarning"),
+        _0x2ea230 = document["getElementById"]("demandMessage");
+      if (_0x3e72d8 && _0x44e783 && _0x2ea230) {
+        let _0x4340e1 = !0x1;
+        _0x3e72d8["addEventListener"]("change", function() {
+          const _0x714556 = this['value'];
+          _0x714556 && '' !== _0x714556 ? updateDeliveryDemandBanner(_0x714556) : _0x44e783['classList']['add']('d-none');
+        }), _0x3e72d8["value"] && '' !== _0x3e72d8['value'] && updateDeliveryDemandBanner(_0x3e72d8["value"]);
+        const _0x5d2821 = document["querySelector"]("#orderModal");
+        _0x5d2821 && _0x5d2821["addEventListener"]('shown.bs.modal', function() {
+          _0x4340e1 || (!(function() {
+            const _0x5c0093 = document["querySelector"]("select[name=\"requestedFor\"]");
+            if (!_0x5c0093) return;
+            const _0x159d18 = document["querySelector"]("input[name=\"csrf_token\"]")?.["value"] || '';
+            fetch('ajax/check_delivery_demand.php', {
+              'method': "POST",
+              'headers': {
+                'Content-Type': "application/json",
+                'X-CSRF-TOKEN': _0x159d18
+              },
+              'body': JSON["stringify"]({
+                'check_all': !0x0
+              })
+            })["then"](_0x1dd51b => _0x1dd51b["json"]())["then"](_0x1131b1 => {
+
+              'success' === _0x1131b1['status'] && _0x1131b1["time_slots"] && _0x5c0093['querySelectorAll']("option[value]:not([value=\"\"])")['forEach'](_0x3f4eee => {
+                const _0x511a78 = _0x3f4eee["value"],
+                  _0xe8231d = [_0x511a78, _0x511a78 + ":00"];
+                let _0x75ed77 = !0x1;
+                for (const _0x70bc3d of _0xe8231d)
+                  if (_0x1131b1['time_slots'][_0x70bc3d] && _0x1131b1["time_slots"][_0x70bc3d]["is_high_demand"]) {
+                    _0x75ed77 = !0x0;
+                    break;
+                  } if (_0x75ed77 && !_0x3f4eee["textContent"]["includes"]("Forte affluence")) {
+                  const _0x138749 = _0x3f4eee['textContent'];
+                  _0x3f4eee['textContent'] = _0x138749 + " (Forte affluence)", _0x3f4eee["style"]['color'] = '#dc3545', _0x3f4eee["classList"]["add"]('high-demand');
+                }
+              });
+            })["catch"](_0x4a1a5e => {
+
+              console["error"]("Error checking all time slots:", _0x4a1a5e);
+            });
+          }()), _0x4340e1 = !0x0);
+        });
+      }
+
+      function updateDeliveryDemandBanner(_0xaa5017) {
+        const _0x56f2bd = document['querySelector']("input[name=\"csrf_token\"]")?.['value'] || '';
+        fetch("ajax/check_delivery_demand.php", {
+          'method': "POST",
+          'headers': {
+            'Content-Type': "application/json",
+            'X-CSRF-TOKEN': _0x56f2bd
+          },
+          'body': JSON["stringify"]({
+            'time': _0xaa5017
+          })
+        })["then"](function(_0x48f486) {
+
+          return _0x48f486["json"]();
+        })["then"](function(_0x4ae253) {
+
+          "success" === _0x4ae253["status"] ? _0x4ae253['is_high_demand'] ? (_0x2ea230["textContent"] = _0x4ae253['message'], _0x44e783["classList"]['remove']("d-none")) : _0x44e783["classList"]["add"]("d-none") : console['error']("Delivery demand check error:", _0x4ae253["message"]);
+        })["catch"](function(_0x749683) {
+
+          console["error"]("Error:", _0x749683);
+        });
+      }
+    } catch (_0x5a8e21) {
+      console["error"]("Delivery demand initialization error:", _0x5a8e21);
+    }
+  });
+  let _0x5ea8af = null,
+    _0x1f3658 = 0x0;
+  const _0x5698d6 = 0x7530;
+  async function fetchStockAvailability() {
+    const _0x489391 = Date["now"]();
+    if (_0x5ea8af && _0x489391 - _0x1f3658 < _0x5698d6) return _0x5ea8af;
+    try {
+      const _0x84bdf2 = await fetch("/office/stock_management.php?type=all");
+      if (!_0x84bdf2['ok']) throw new Error("Stock status fetch failed");
+      const _0x268bb7 = await _0x84bdf2["json"]();
+      return _0x5ea8af = _0x268bb7, _0x1f3658 = _0x489391, _0x268bb7;
+    } catch (_0x156f59) {
+      return console["error"]('Stock\x20status\x20fetch\x20error:', _0x156f59), null;
+    }
+  }
+
+  function isStockAvailable(_0xb7fdca, _0x39315a) {
+
+    if (!_0x5ea8af || !_0x5ea8af[_0xb7fdca]) return !0x0;
+    const _0x17f524 = _0x5ea8af[_0xb7fdca][_0x39315a];
+    return !_0x17f524 || _0x17f524["in_stock"];
+  }
+
+  function applyStockAvailability() {
+
+    _0x5ea8af && (document['querySelectorAll']("input[name=\"viande\"], input[name=\"viande[]\"]")["forEach"](_0x4f4d8b => {
+      const _0x59a8cf = isStockAvailable("viandes", _0x4f4d8b["value"]),
+        _0x3b55c1 = _0x4f4d8b["closest"]("label") || _0x4f4d8b["parentElement"],
+        _0xe13b65 = _0x4f4d8b['closest'](".meat-selection-row") || _0x4f4d8b["closest"]('.form-check');
+      if (_0x59a8cf) {
+        if (_0x4f4d8b["disabled"] = !0x1, _0xe13b65 && (_0xe13b65["style"]["opacity"] = '1', _0xe13b65["style"]["pointerEvents"] = "auto"), _0x3b55c1) {
+          const _0xb43f9d = _0x3b55c1["querySelector"](".out-of-stock-text");
+          _0xb43f9d && _0xb43f9d["remove"]();
+        }
+      } else {
+        if (_0x4f4d8b["disabled"] = !0x0, _0x4f4d8b["checked"] = !0x1, _0xe13b65 && (_0xe13b65["style"]["opacity"] = "0.5", _0xe13b65["style"]["pointerEvents"] = 'none'), _0x3b55c1) {
+          if (!_0x3b55c1["querySelector"](".out-of-stock-text")) {
+            const _0x59635d = document["createElement"]("span");
+            _0x59635d["className"] = 'out-of-stock-text\x20text-danger\x20ms-2\x20fw-bold', _0x59635d['textContent'] = " (Temporairement \u00e9puis\u00e9)", _0x3b55c1['appendChild'](_0x59635d);
+          }
+        }
+      }
+    }), document["querySelectorAll"]("input[name^=\"garniture\"]")["forEach"](_0x2f3121 => {
+      const _0xbeee21 = isStockAvailable('garnitures', _0x2f3121["value"]),
+        _0x5f2b83 = _0x2f3121["closest"]("label") || _0x2f3121["parentElement"]["querySelector"]("label");
+      if (_0xbeee21) {
+        if (_0x2f3121["disabled"] = !0x1, _0x5f2b83) {
+          const _0x28ac24 = _0x5f2b83["querySelector"](".out-of-stock-text");
+          _0x28ac24 && _0x28ac24["remove"]();
+        }
+      } else {
+        if (_0x2f3121["disabled"] = !0x0, _0x5f2b83) {
+          if (!_0x5f2b83["querySelector"](".out-of-stock-text")) {
+            const _0x3418cb = document["createElement"]("span");
+            _0x3418cb['className'] = "out-of-stock-text text-danger ms-2", _0x3418cb["textContent"] = "(Temporairement \u00e9puis\u00e9)", _0x5f2b83["appendChild"](_0x3418cb);
+          }
+        }
+      }
+    }), document["querySelectorAll"]("input[name^=\"sauce\"]")["forEach"](_0x1e2af4 => {
+      const _0xbc0540 = isStockAvailable("sauces", _0x1e2af4["value"]),
+        _0x30894d = _0x1e2af4["closest"]("label") || _0x1e2af4["parentElement"]["querySelector"]("label");
+      if (_0xbc0540) {
+        if (_0x1e2af4["disabled"] = !0x1, _0x30894d) {
+          const _0xbb91d = _0x30894d["querySelector"](".out-of-stock-text");
+          _0xbb91d && _0xbb91d["remove"]();
+        }
+      } else {
+        if (_0x1e2af4['disabled'] = !0x0, _0x30894d) {
+          if (!_0x30894d["querySelector"](".out-of-stock-text")) {
+            const _0x28808a = document['createElement']("span");
+            _0x28808a["className"] = 'out-of-stock-text\x20text-danger\x20ms-2', _0x28808a["textContent"] = "(Temporairement \u00e9puis\u00e9)", _0x30894d["appendChild"](_0x28808a);
+          }
+        }
+      }
+    }), document["querySelectorAll"]('input[name=\x22dessert\x22]')['forEach'](_0x53687d => {
+      const _0x113c12 = isStockAvailable("desserts", _0x53687d["value"]),
+        _0x3cb37e = _0x53687d["closest"]("label") || _0x53687d["parentElement"]["querySelector"]("label");
+      if (_0x113c12) {
+        if (_0x53687d["disabled"] = !0x1, _0x3cb37e) {
+          const _0x56cfef = _0x3cb37e["querySelector"](".out-of-stock-text");
+          _0x56cfef && _0x56cfef["remove"]();
+        }
+      } else {
+        if (_0x53687d["disabled"] = !0x0, _0x3cb37e) {
+          if (!_0x3cb37e['querySelector']('.out-of-stock-text')) {
+            const _0x195c6e = document["createElement"]('span');
+            _0x195c6e["className"] = "out-of-stock-text text-danger ms-2", _0x195c6e["textContent"] = "(Temporairement \u00e9puis\u00e9)", _0x3cb37e['appendChild'](_0x195c6e);
+          }
+        }
+      }
+    }), document["querySelectorAll"]("input[name=\"boisson\"]")["forEach"](_0x4c53fb => {
+      const _0x11b404 = isStockAvailable("boissons", _0x4c53fb["value"]),
+        _0x2319d0 = _0x4c53fb["closest"]("label") || _0x4c53fb["parentElement"]['querySelector']("label");
+      if (_0x11b404) {
+        if (_0x4c53fb['disabled'] = !0x1, _0x2319d0) {
+          const _0x56b33f = _0x2319d0["querySelector"](".out-of-stock-text");
+          _0x56b33f && _0x56b33f["remove"]();
+        }
+      } else {
+        if (_0x4c53fb['disabled'] = !0x0, _0x2319d0) {
+          if (!_0x2319d0["querySelector"]('.out-of-stock-text')) {
+            const _0x33a835 = document["createElement"]('span');
+            _0x33a835["className"] = 'out-of-stock-text\x20text-danger\x20ms-2', _0x33a835["textContent"] = "(Temporairement \u00e9puis\u00e9)", _0x2319d0["appendChild"](_0x33a835);
+          }
+        }
+      }
+    }), document["querySelectorAll"]("input[name=\"extra[]\"]")['forEach'](_0xa04f05 => {
+      const _0x492cae = isStockAvailable("extras", _0xa04f05["value"]),
+        _0x177665 = _0xa04f05["closest"]("label") || _0xa04f05["parentElement"]['querySelector']("label");
+      if (_0x492cae) {
+        if (_0xa04f05['disabled'] = !0x1, _0x177665) {
+          const _0x5a7a79 = _0x177665["querySelector"]('.out-of-stock-text');
+          _0x5a7a79 && _0x5a7a79["remove"]();
+        }
+      } else {
+        if (_0xa04f05["disabled"] = !0x0, _0x177665) {
+          if (!_0x177665["querySelector"](".out-of-stock-text")) {
+            const _0xfd0b7f = document["createElement"]("span");
+            _0xfd0b7f["className"] = "out-of-stock-text text-danger ms-2", _0xfd0b7f['textContent'] = '(Temporairement\x20épuisé)', _0x177665['appendChild'](_0xfd0b7f);
+          }
+        }
+      }
+    }));
+  }
+  document["addEventListener"]('DOMContentLoaded', async function() {
+    await fetchStockAvailability(), applyStockAvailability();
+  }), document['querySelectorAll']('.modal')['forEach'](_0x3e4f02 => {
+
+    _0x3e4f02["addEventListener"]("shown.bs.modal", async function() {
+      await fetchStockAvailability(), applyStockAvailability();
+    });
+  }), (function() {
+    const _0x835a6 = document["getElementById"]("address"),
+      _0x45319d = document['getElementById']("autocompleteDropdown");
+    if (!_0x835a6 || !_0x45319d) return;
+    let _0x399085, _0x37c153 = -0x1,
+      _0x433fe5 = [];
+
+    function getPostalCodeFromSummary() {
+      const _0x1cfdd3 = document["querySelector"]('.col-4.mt-5.border.rounded\x20.text-center.mt-1.small');
+      if (_0x1cfdd3 && 'N/A' !== _0x1cfdd3["textContent"]['trim']()) {
+        const _0x26be6e = _0x1cfdd3["textContent"]['trim']()['match'](/^(\d{4})/);
+        return _0x26be6e ? _0x26be6e[0x1] : null;
+      }
+      return null;
+    }
+
+    function setActiveAutocompleteItem(_0x269678) {
+
+      _0x45319d['querySelectorAll'](".autocomplete-item")['forEach']((_0x3d7fd2, _0xd51701) => {
+
+        _0x3d7fd2['classList']["toggle"]("active", _0xd51701 === _0x269678);
+      }), _0x37c153 = _0x269678;
+    }
+
+    function selectAutocompleteSuggestion(_0x5af39e) {
+      const _0x239e83 = _0x5af39e["address"]?.["road"] || _0x5af39e["address"]?.['pedestrian'] || '',
+        _0xb382b6 = _0x5af39e["address"]?.["house_number"] || '',
+        _0x1877bd = _0x835a6["value"]["trim"]()['split'](/\s+/),
+        _0x5cf1ed = _0x1877bd[_0x1877bd["length"] - 0x1],
+        _0x6fbbce = /^\d+$/ ["test"](_0x5cf1ed);
+      _0x835a6["value"] = _0xb382b6 ? _0x239e83 + '\x20' + _0xb382b6 : _0x6fbbce ? _0x239e83 + '\x20' + _0x5cf1ed : _0x239e83, _0x45319d["classList"]["remove"]("show"), setTimeout(() => {
+
+        _0x835a6["focus"]();
+        const _0x3a7f81 = _0x835a6["value"]["length"];
+        _0x835a6['setSelectionRange'](_0x3a7f81, _0x3a7f81);
+      }, 0x64);
+    }
+    _0x835a6['addEventListener']("input", function() {
+      clearTimeout(_0x399085), _0x399085 = setTimeout(async () => {
+        const _0x31e95b = _0x835a6["value"]['trim'](),
+          _0x44eb71 = getPostalCodeFromSummary();
+        if (_0x31e95b["length"] < 0x3) return void _0x45319d['classList']["remove"]("show");
+        if (!_0x44eb71) return void _0x45319d['classList']["remove"]("show");
+        const _0x3cb753 = await async function(_0x24dec1, _0x42ea81) {
+          const _0x986eba = _0x153108;
+          if (!_0x42ea81 || _0x24dec1[_0x986eba(0x337)] < 0x3) return [];
+          const _0x15638e = function(_0x388cd3) {
+              const _0x1f5e81 = _0x986eba,
+                _0x2410ad = [{
+                  'pattern': /\bchem\.\s*/gi,
+                  'replacement': _0x1f5e81(0x1d6)
+                }, {
+                  'pattern': /\bch\.\s*/gi,
+                  'replacement': _0x1f5e81(0x1d6)
+                }, {
+                  'pattern': /\bav\.\s*/gi,
+                  'replacement': _0x1f5e81(0x1cb)
+                }, {
+                  'pattern': /\bbd\s+/gi,
+                  'replacement': 'Boulevard\x20'
+                }, {
+                  'pattern': /\bpl\.\s*/gi,
+                  'replacement': _0x1f5e81(0x275)
+                }, {
+                  'pattern': /\brte\s+/gi,
+                  'replacement': _0x1f5e81(0x161)
+                }, {
+                  'pattern': /\br\.\s*/gi,
+                  'replacement': 'Rue\x20'
+                }];
+              let _0x2afc98 = _0x388cd3;
+              for (const {
+                  pattern: _0x819801,
+                  replacement: _0x29838b
+                }
+                of _0x2410ad) _0x2afc98 = _0x2afc98[_0x1f5e81(0x24d)](_0x819801, _0x29838b);
+              return _0x2afc98;
+            }(_0x24dec1),
+            _0x1545c5 = _0x986eba(0x33f) + new URLSearchParams({
+              'street': _0x15638e,
+              'postalcode': _0x42ea81,
+              'country': _0x986eba(0x168),
+              'format': 'json',
+              'addressdetails': '1',
+              'limit': '10',
+              'layer': _0x986eba(0x2e1)
+            })[_0x986eba(0x235)]();
+          try {
+            const _0x45a15e = await fetch(_0x1545c5, {
+              'headers': {
+                'User-Agent': _0x986eba(0x265)
+              }
+            });
+            return await _0x45a15e[_0x986eba(0x290)]();
+          } catch (_0x3c4d3c) {
+            return console[_0x986eba(0x2b6)]('Nominatim\x20error:', _0x3c4d3c), [];
+          }
+        }(_0x31e95b, _0x44eb71);
+        ! function(_0x4264d0) {
+          const _0x3c09f7 = getPostalCodeFromSummary(),
+            _0x3f7095 = new Map();
+          _0x4264d0['forEach'](_0x186e41 => {
+            const _0x596a1b = _0x186e41["address"]?.['road'] || _0x186e41["address"]?.["pedestrian"] || '',
+              _0x54547e = _0x186e41["address"]?.["postcode"] || '';
+            _0x596a1b && !_0x3f7095['has'](_0x596a1b) && (_0x186e41["_isExactMatch"] = _0x54547e === _0x3c09f7, _0x3f7095["set"](_0x596a1b, _0x186e41));
+          }), _0x433fe5 = Array["from"](_0x3f7095["values"]())["sort"]((_0x5b9b7c, _0x257579) => _0x5b9b7c["_isExactMatch"] && !_0x257579["_isExactMatch"] ? -0x1 : !_0x5b9b7c["_isExactMatch"] && _0x257579["_isExactMatch"] ? 0x1 : 0x0), _0x37c153 = -0x1, 0x0 !== _0x433fe5["length"] ? (_0x45319d['innerHTML'] = '', _0x433fe5['forEach']((_0x444a31, _0x1f1f36) => {
+            const _0x4974aa = document["createElement"]('div');
+            _0x4974aa["className"] = "autocomplete-item", _0x4974aa["dataset"]['index'] = _0x1f1f36;
+            const _0x4d8f1f = _0x444a31["address"]?.['road'] || _0x444a31["address"]?.['pedestrian'] || '',
+              _0x2f6956 = _0x444a31['address']?.["house_number"] || '',
+              _0x4cbeb8 = _0x2f6956 ? _0x4d8f1f + '\x20' + _0x2f6956 : _0x4d8f1f;
+            _0x4974aa["innerHTML"] = "\n        <div class=\"street\">" + _0x4cbeb8 + "</div>\n      ", _0x4974aa['addEventListener']("touchstart", _0xb84463 => {
+              _0xb84463['preventDefault'](), selectAutocompleteSuggestion(_0x444a31);
+            }), _0x4974aa["addEventListener"]("click", _0x4a88e9 => {
+
+              _0x4a88e9["preventDefault"](), selectAutocompleteSuggestion(_0x444a31);
+            }), _0x4974aa["addEventListener"]("mouseenter", () => setActiveAutocompleteItem(_0x1f1f36)), _0x45319d["appendChild"](_0x4974aa);
+          }), _0x45319d['classList']['add']('show')) : _0x45319d['classList']['remove']("show");
+        }(_0x3cb753);
+      }, 0x12c);
+    }), _0x835a6["addEventListener"]("keydown", _0x1dccf4 => {
+      const _0x532d40 = _0x45319d["querySelectorAll"](".autocomplete-item");
+      "ArrowDown" === _0x1dccf4["key"] ? (_0x1dccf4["preventDefault"](), _0x37c153 = Math['min'](_0x37c153 + 0x1, _0x532d40["length"] - 0x1), setActiveAutocompleteItem(_0x37c153)) : "ArrowUp" === _0x1dccf4["key"] ? (_0x1dccf4["preventDefault"](), _0x37c153 = Math["max"](_0x37c153 - 0x1, 0x0), setActiveAutocompleteItem(_0x37c153)) : 'Enter' === _0x1dccf4["key"] ? _0x37c153 >= 0x0 && _0x433fe5[_0x37c153] && (_0x1dccf4["preventDefault"](), selectAutocompleteSuggestion(_0x433fe5[_0x37c153])) : "Escape" === _0x1dccf4["key"] && _0x45319d["classList"]["remove"]("show");
+    }), document["addEventListener"]("click", _0x3ccbb9 => {
+
+      _0x45319d['contains'](_0x3ccbb9["target"]) || _0x3ccbb9['target'] === _0x835a6 || _0x45319d['classList']["remove"]("show");
+    });
+  }());
+})()));


### PR DESCRIPTION
## Summary
- rename the frequently used helper functions in `bundle.js` to descriptive names such as `refreshOrderHistory`, `buildOrderItemsList`, and `refreshCartSummary`
- rewrite the quantity-update and selection-limit helpers with clearer variables and structure to improve readability when updating taco selections
- clean up the category badge, cart summary, and order item rendering helpers to use descriptive local variables and modernized flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904d2e728c08330a388217cd8fe5097