### PR TITLE
fix: show expired status for orders past their endDate

### DIFF
--- a/apps/api/scripts/migrate-badges.ts
+++ b/apps/api/scripts/migrate-badges.ts
@@ -365,12 +365,12 @@ async function migrateUserBadges() {
       select: { id: true },
     });
 
-    // Get group orders led (submitted or completed)
-    // Note: This counts orders where the user was the leader and submitted/completed them
+    // Get group orders led (submitted)
+    // Note: This counts orders where the user was the leader and submitted them
     const groupOrdersLed = await prisma.groupOrder.count({
       where: {
         leaderId: user.id,
-        status: { in: ['submitted', 'completed'] },
+        status: 'submitted',
       },
     });
 

--- a/apps/api/src/api/routes/group-order.routes.ts
+++ b/apps/api/src/api/routes/group-order.routes.ts
@@ -13,6 +13,7 @@ import {
   canSubmitGroupOrder,
   type GroupOrder,
   GroupOrderId,
+  getEffectiveStatus,
 } from '@/schemas/group-order.schema';
 import { OrganizationId } from '@/schemas/organization.schema';
 import { UserId } from '@/schemas/user.schema';
@@ -60,7 +61,7 @@ async function serializeGroupOrderResponse(groupOrder: GroupOrder) {
     name: groupOrder.name ?? null,
     startDate: groupOrder.startDate.toISOString(),
     endDate: groupOrder.endDate.toISOString(),
-    status: groupOrder.status,
+    status: getEffectiveStatus(groupOrder),
     canAcceptOrders: canAcceptOrders(groupOrder),
     canSubmitGroupOrder: canSubmitGroupOrder(groupOrder),
     fee: groupOrder.fee ?? null,

--- a/apps/api/src/api/routes/user-order.routes.ts
+++ b/apps/api/src/api/routes/user-order.routes.ts
@@ -542,8 +542,8 @@ app.openapi(
       throw new NotFoundError({ resource: 'GroupOrder', id: groupOrderId });
     }
 
-    // Check permissions: leader can always reveal, or anyone if order is submitted/completed
-    const isSubmitted = groupOrder.status === 'submitted' || groupOrder.status === 'completed';
+    // Check permissions: leader can always reveal, or anyone if order is submitted
+    const isSubmitted = groupOrder.status === 'submitted';
     const isLeader = groupOrder.leaderId === requesterId;
 
     if (!isLeader && !isSubmitted) {

--- a/apps/api/src/schemas/group-order.schema.ts
+++ b/apps/api/src/schemas/group-order.schema.ts
@@ -2,7 +2,7 @@
  * Group order domain schema (Zod)
  * @module schemas/group-order
  */
-import { isWithinInterval } from 'date-fns';
+import { isAfter, isWithinInterval } from 'date-fns';
 import { z } from 'zod';
 import { UserId } from '@/schemas/user.schema';
 import { GroupOrderStatus } from '@/shared/types/types';
@@ -174,4 +174,21 @@ export function canAcceptOrders(order: GroupOrder, referenceDate = new Date()): 
  */
 export function canSubmitGroupOrder(order: GroupOrder): boolean {
   return order.status === GroupOrderStatus.OPEN;
+}
+
+/**
+ * Get the effective display status for a group order.
+ * Returns EXPIRED when status is OPEN but current time > endDate.
+ */
+export function getEffectiveStatus(
+  order: GroupOrder,
+  referenceDate = new Date()
+): GroupOrderStatus {
+  if (order.status !== GroupOrderStatus.OPEN) {
+    return order.status;
+  }
+  if (isAfter(referenceDate, order.endDate)) {
+    return GroupOrderStatus.EXPIRED;
+  }
+  return order.status;
 }

--- a/apps/api/src/shared/types/types.ts
+++ b/apps/api/src/shared/types/types.ts
@@ -207,7 +207,7 @@ export enum GroupOrderStatus {
   OPEN = 'open',
   CLOSED = 'closed',
   SUBMITTED = 'submitted',
-  COMPLETED = 'completed',
+  EXPIRED = 'expired',
 }
 
 /**

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -402,8 +402,8 @@
     "status": {
       "active": "Aktiv",
       "closed": "Geschlossen",
-      "completed": "Abgeschlossen",
       "draft": "Entwurf",
+      "expired": "Abgelaufen",
       "open": "Offen",
       "pending": "Ausstehend",
       "submitted": "Abgesendet"
@@ -892,7 +892,6 @@
           "closeOrder": "Bestellung schließen",
           "closedReasons": {
             "closed": "Bestellung geschlossen",
-            "completed": "Bestellung abgeschlossen",
             "expired": "Bestellzeitraum abgelaufen",
             "notStarted": "Bestellzeitraum noch nicht gestartet",
             "open": "Bestellzeitraum abgelaufen",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -402,8 +402,8 @@
     "status": {
       "active": "Active",
       "closed": "Closed",
-      "completed": "Completed",
       "draft": "Draft",
+      "expired": "Expired",
       "open": "Open",
       "pending": "Pending",
       "submitted": "Submitted"
@@ -892,7 +892,6 @@
           "closeOrder": "Close order",
           "closedReasons": {
             "closed": "Order closed",
-            "completed": "Order completed",
             "expired": "Order period expired",
             "notStarted": "Order period not started yet",
             "open": "Order period expired",

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -402,8 +402,8 @@
     "status": {
       "active": "Active",
       "closed": "Fermée",
-      "completed": "Terminée",
       "draft": "Brouillon",
+      "expired": "Expirée",
       "open": "Ouverte",
       "pending": "En attente",
       "submitted": "Transmise"
@@ -892,7 +892,6 @@
           "closeOrder": "Fermer la commande",
           "closedReasons": {
             "closed": "Commande clôturée",
-            "completed": "Commande terminée",
             "expired": "Créneau expiré",
             "notStarted": "Créneau pas encore commencé",
             "open": "Créneau expiré",

--- a/packages/ui-kit/src/status-badge.tsx
+++ b/packages/ui-kit/src/status-badge.tsx
@@ -7,12 +7,12 @@ type StatusToneOverrides = Partial<Record<string, BadgeTone>>;
 
 const DEFAULT_STATUS_TONES: Record<string, BadgeTone> = {
   submitted: 'success',
-  completed: 'success',
   pending: 'warning',
   open: 'warning',
   active: 'brand',
   draft: 'neutral',
   closed: 'neutral',
+  expired: 'neutral',
 };
 
 type StatusBadgeProps = Omit<ComponentPropsWithoutRef<typeof Badge>, 'tone' | 'pill'> & {


### PR DESCRIPTION
## Summary
- Compute effective display status in API response - when a group order has status OPEN but current time > endDate, return EXPIRED instead
- Replace unused COMPLETED with EXPIRED in GroupOrderStatus enum
- Add `getEffectiveStatus()` function to compute display status
- Add expired status styling (neutral tone) and translations (en/fr/de)

## Test plan
- [ ] Create a group order with endDate in the past
- [ ] Verify the status badge shows "Expired" instead of "Open"
- [ ] Verify orders with future endDate still show "Open"
- [ ] Verify closed/submitted orders display correctly

Fixes #13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Highlights the overdue state in API and UI.
> 
> - Add `getEffectiveStatus()` to compute display status; API now returns `expired` when `status` is `open` and `endDate` has passed
> - Replace unused `completed` with `expired` in `GroupOrderStatus`; update imports and date utils
> - Adjust reveal-permissions: treat only `submitted` as revealable (remove `completed` checks)
> - Migration script: count `groupOrdersLed` only when `status` is `submitted`
> - Update translations (en/fr/de) and `StatusBadge` tones to include `expired` and remove `completed`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6ed4391b748d3b6d332b256f1bb2ded9a184eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->